### PR TITLE
Improve error message when joining a log with an entry with invalid signature

### DIFF
--- a/src/log.js
+++ b/src/log.js
@@ -270,9 +270,7 @@ class Log extends GSet {
         try {
           await Entry.verifyEntry(entry, this._keystore)
         } catch (e) {
-          console.log(e)
-          console.log("Couldn't verify entry:\n", entry)
-          return false
+          throw new Error(`Invalid signature in entry '${entry.hash}'`)
         }
 
         return true

--- a/test/signed-log.spec.js
+++ b/test/signed-log.spec.js
@@ -248,12 +248,17 @@ apis.forEach((IPFS) => {
 
       const log1 = new Log(ipfs, 'A', null, null, null, key1, [key1.getPublic('hex'), key2.getPublic('hex')])
       const log2 = new Log(ipfs, 'A', null, null, null, key2, [key1.getPublic('hex'), key2.getPublic('hex')])
+      let err
 
-      await log1.append('one')
-      await log2.append('two')
-      log2.values[0].sig = replaceAt(log2.values[0].sig, 0, 'X')
-      await log1.join(log2)
-
+      try {
+        await log1.append('one')
+        await log2.append('two')
+        log2.values[0].sig = replaceAt(log2.values[0].sig, 0, 'X')
+        await log1.join(log2)
+      } catch (e) {
+        err = e.toString()
+      }
+      assert.equal(err, `Error: Invalid signature in entry '${log2.values[0].hash}'`)
       assert.equal(log1.values.length, 1)
       assert.equal(log1.values[0].payload, 'one')
     })


### PR DESCRIPTION
This PR will throw a nicer error when trying to join a log with an entry that has an invalid signature.

It will now throw:
`Error: Invalid signature in entry '<hash>'`