### PR TITLE
Feature/keys and permissions

### DIFF
--- a/src/entry.js
+++ b/src/entry.js
@@ -59,20 +59,6 @@ class Entry {
     return entry
   }
 
-  static async verifyEntry (entry, keystore) {
-    const e = Object.assign({}, {
-      hash: null,
-      id: entry.id,
-      payload: entry.payload,
-      next: entry.next,
-      v: entry.v,
-      clock: entry.clock,
-    })
-
-    const pubKey = await keystore.importPublicKey(entry.key)
-    await keystore.verify(entry.sig, pubKey, Buffer.from(JSON.stringify(e)))
-  }
-
   /**
    * Get the multihash of an Entry
    * @param {IPFS} [ipfs] An IPFS instance

--- a/src/entry.js
+++ b/src/entry.js
@@ -17,7 +17,7 @@ class Entry {
    * // { hash: "Qm...Foo", payload: "hello", next: [] }
    * @returns {Promise<Entry>}
    */
-  static async create (ipfs, keystore, id, data, next = [], clock, signKey) {
+  static async create (ipfs, keystore, id, data, next = [], clock, signKey, decorateFn) {
     if (!isDefined(ipfs)) throw IpfsNotDefinedError()
     if (!isDefined(id)) throw new Error('Entry requires an id')
     if (!isDefined(data)) throw new Error('Entry requires data')
@@ -43,19 +43,25 @@ class Entry {
       clock: new Clock(clockId, clockTime),
     }
 
-    // If signing key was passedd, sign the enrty
+    // If signing key was passed, sign the entry
     if (keystore && signKey) {
-      entry = await Entry.signEntry(keystore, entry, signKey) 
+      entry = await Entry.signEntry(keystore, entry, signKey, decorateFn)
     }
 
     entry.hash = await Entry.toMultihash(ipfs, entry)
     return entry
   }
 
-  static async signEntry (keystore, entry, key) {
+  static async signEntry (keystore, entry, key, decorateFn) {
     const signature = await keystore.sign(key, Buffer.from(JSON.stringify(entry)))
     entry.sig = signature
     entry.key = key.getPublic('hex')
+
+    if (decorate) {
+      const chainSignature = await decorateFn(entry.key)
+      entry.chainSignature = chainSignature
+    }
+
     return entry
   }
 

--- a/src/log.js
+++ b/src/log.js
@@ -197,6 +197,7 @@ class Log extends GSet {
    * @param  {Entry} entry Entry to add
    * @return {Log}   New Log containing the appended value
    */
+  async append(data, pointerCount = 1, decorateFn) {
     // Update the clock (find the latest clock)
     const newTime = Math.max(this.clock.time, this.heads.reduce(maxClockTimeReducer, 0)) + 1
     this._clock = new Clock(this.clock.id, newTime)
@@ -211,6 +212,8 @@ class Log extends GSet {
     // Update the length
     this._length ++
     return entry
+  };
+
   difference(log) {
     let stack = Object.keys(log._headsIndex);
     let traversed = {};

--- a/src/log.js
+++ b/src/log.js
@@ -197,14 +197,6 @@ class Log extends GSet {
    * @param  {Entry} entry Entry to add
    * @return {Log}   New Log containing the appended value
    */
-  async append (data, pointerCount = 1) {
-    // Verify that we're allowed to append
-    if ((this._key && this._key.getPublic)
-        && !this._keys.includes(this._key.getPublic('hex')) 
-        && !this._keys.includes('*')) {
-      throw new Error("Not allowed to write")
-    }
-
     // Update the clock (find the latest clock)
     const newTime = Math.max(this.clock.time, this.heads.reduce(maxClockTimeReducer, 0)) + 1
     this._clock = new Clock(this.clock.id, newTime)


### PR DESCRIPTION
This is the `ipfs-log` PR designed to work with an `orbit-db-store` PR, and a new repo `orbit-db-access-controllers` (which can simply become a PR to `orbit-db` if desired).

This PR adds a method `difference` to the log, so that `orbit-db-store` can verify permissions and signing. It removes verification from the log altogether, and it allows an extra signing function to be passed in.

See also the [orbit-db-access-controller](https://github.com/coyotespike/orbit-db-access-controller) repo, although it has nothing interesting as of yet.