### PR TITLE
tests: add benchmarks for log.values, log.has(), log.get()

### DIFF
--- a/benchmarks/benchmark-get-plus.js
+++ b/benchmarks/benchmark-get-plus.js
@@ -1,0 +1,108 @@
+'use strict'
+
+const Log = require('../src/log')
+const IPFS = require('ipfs')
+const IPFSRepo = require('ipfs-repo')
+const DatastoreLevel = require('datastore-level')
+
+// State
+let ipfs
+let log
+
+// Metrics
+let totalQueries = 0
+let seconds = 0
+let queriesPerSecond = 0
+let lastTenSeconds = 0
+
+let entry
+let immediate
+
+let waveCount = 0
+let waveLength = 10 // seconds
+
+let addEntries = async () => {
+  for (let i=0; i<10000; i++) {
+    await log.append(`Hello World: ${i}`)
+  }
+
+  // choose random entry
+  entry = log.values[Math.floor(Math.random() * log.values.length)]
+
+  console.log(`=== Running wave #${waveCount} for ${waveLength} seconds  with ${log.values.length} entries ===`)
+}
+
+const queryLoop = async () => {
+  log.get(entry.hash)
+  totalQueries++
+  lastTenSeconds++
+  queriesPerSecond++
+  immediate = setImmediate(queryLoop)
+}
+
+let run = (() => {
+  console.log('Starting benchmark...')
+
+  const repoConf = {
+    storageBackends: {
+      blocks: DatastoreLevel
+    }
+  }
+
+  ipfs = new IPFS({
+    repo: new IPFSRepo('./ipfs-log-benchmarks/ipfs', repoConf),
+    start: false,
+    EXPERIMENTAL: {
+      pubsub: false,
+      sharding: false,
+      dht: false,
+    },
+  })
+
+  ipfs.on('error', (err) => {
+    console.error(err)
+  })
+
+  ipfs.on('ready', async () => {
+    // Create a log
+    log = new Log(ipfs, 'A')
+
+    await addEntries()
+
+    const nextWave = async () => {
+      //reset counters
+      totalQueries = 0
+      seconds = 0
+      queriesPerSecond = 0
+      lastTenSeconds = 0
+
+      waveCount++
+      await addEntries()
+
+      interval = setInterval(outputMetrics, 1000)
+      immediate = setImmediate(queryLoop)
+    }
+
+    const outputMetrics = () => {
+      seconds++
+
+      console.log(`${queriesPerSecond} queries per second, ${totalQueries} queries in ${seconds} seconds (Entry count: ${log.values.length})`)
+      queriesPerSecond = 0
+
+      if (seconds % waveLength === 0) {
+        console.log(`--> Average of ${lastTenSeconds / 10} q/s in this wave`)
+        if (lastTenSeconds === 0) throw new Error('Problems!')
+        lastTenSeconds = 0
+        clearImmediate(immediate)
+        clearInterval(interval)
+        nextWave()
+      }
+    }
+
+    // Output metrics at 1 second interval
+    let interval = setInterval(outputMetrics, 1000)
+    immediate = setImmediate(queryLoop)
+  })
+})()
+
+module.exports = run

--- a/benchmarks/benchmark-get-plus.js
+++ b/benchmarks/benchmark-get-plus.js
@@ -20,16 +20,17 @@ let immediate
 
 let waveCount = 0
 let waveLength = 10 // seconds
+let waveDepth = parseInt(process.argv[2], 10) || 10000
 
 let addEntries = async () => {
-  for (let i=0; i<10000; i++) {
+  for (let i=0; i<waveDepth; i++) {
     await log.append(`Hello World: ${i}`)
   }
 
   // choose random entry
   entry = log.values[Math.floor(Math.random() * log.values.length)]
 
-  console.log(`=== Running wave #${waveCount} for ${waveLength} seconds  with ${log.values.length} entries ===`)
+  console.log(`=== Running wave #${waveCount} for ${waveLength} seconds with ${log.values.length} entries ===`)
 }
 
 const queryLoop = async () => {

--- a/benchmarks/benchmark-get.js
+++ b/benchmarks/benchmark-get.js
@@ -1,0 +1,73 @@
+'use strict'
+
+const Log = require('../src/log')
+const IPFS = require('ipfs')
+const IPFSRepo = require('ipfs-repo')
+const DatastoreLevel = require('datastore-level')
+
+// State
+let ipfs
+let log
+
+// Metrics
+let totalQueries = 0
+let seconds = 0
+let queriesPerSecond = 0
+let lastTenSeconds = 0
+
+let entry
+
+const queryLoop = async () => {
+  log.get(entry.hash)
+  totalQueries++
+  lastTenSeconds++
+  queriesPerSecond++
+  setImmediate(queryLoop)
+}
+
+let run = (() => {
+  console.log('Starting benchmark...')
+
+  const repoConf = {
+    storageBackends: {
+      blocks: DatastoreLevel
+    }
+  }
+
+  ipfs = new IPFS({
+    repo: new IPFSRepo('./ipfs-log-benchmarks/ipfs', repoConf),
+    start: false,
+    EXPERIMENTAL: {
+      pubsub: false,
+      sharding: false,
+      dht: false,
+    },
+  })
+
+  ipfs.on('error', (err) => {
+    console.error(err)
+  })
+
+  ipfs.on('ready', async () => {
+    // Create a log
+    log = new Log(ipfs, 'A')
+
+    entry = await log.append('Hello World')
+
+    // Output metrics at 1 second interval
+    setInterval(() => {
+      seconds++
+      if (seconds % 10 === 0) {
+        console.log(`--> Average of ${lastTenSeconds / 10} q/s in the last 10 seconds`)
+        if (lastTenSeconds === 0) throw new Error('Problems!')
+        lastTenSeconds = 0
+      }
+      console.log(`${queriesPerSecond} queries per second, ${totalQueries} queries in ${seconds} seconds (Entry count: ${log.values.length})`)
+      queriesPerSecond = 0
+    }, 1000)
+
+    setImmediate(queryLoop)
+  })
+})()
+
+module.exports = run

--- a/benchmarks/benchmark-has-plus.js
+++ b/benchmarks/benchmark-has-plus.js
@@ -1,0 +1,108 @@
+'use strict'
+
+const Log = require('../src/log')
+const IPFS = require('ipfs')
+const IPFSRepo = require('ipfs-repo')
+const DatastoreLevel = require('datastore-level')
+
+// State
+let ipfs
+let log
+
+// Metrics
+let totalQueries = 0
+let seconds = 0
+let queriesPerSecond = 0
+let lastTenSeconds = 0
+
+let entry
+let immediate
+
+let waveCount = 0
+let waveLength = 10 // seconds
+
+let addEntries = async () => {
+  for (let i=0; i<10000; i++) {
+    await log.append(`Hello World: ${i}`)
+  }
+
+  // choose random entry
+  entry = log.values[Math.floor(Math.random() * log.values.length)]
+
+  console.log(`=== Running wave #${waveCount} for ${waveLength} seconds  with ${log.values.length} entries ===`)
+}
+
+const queryLoop = async () => {
+  log.has(entry.hash)
+  totalQueries++
+  lastTenSeconds++
+  queriesPerSecond++
+  immediate = setImmediate(queryLoop)
+}
+
+let run = (() => {
+  console.log('Starting benchmark...')
+
+  const repoConf = {
+    storageBackends: {
+      blocks: DatastoreLevel
+    }
+  }
+
+  ipfs = new IPFS({
+    repo: new IPFSRepo('./ipfs-log-benchmarks/ipfs', repoConf),
+    start: false,
+    EXPERIMENTAL: {
+      pubsub: false,
+      sharding: false,
+      dht: false,
+    },
+  })
+
+  ipfs.on('error', (err) => {
+    console.error(err)
+  })
+
+  ipfs.on('ready', async () => {
+    // Create a log
+    log = new Log(ipfs, 'A')
+
+    await addEntries()
+
+    const nextWave = async () => {
+      //reset counters
+      totalQueries = 0
+      seconds = 0
+      queriesPerSecond = 0
+      lastTenSeconds = 0
+
+      waveCount++
+      await addEntries()
+
+      interval = setInterval(outputMetrics, 1000)
+      immediate = setImmediate(queryLoop)
+    }
+
+    const outputMetrics = () => {
+      seconds++
+
+      console.log(`${queriesPerSecond} queries per second, ${totalQueries} queries in ${seconds} seconds (Entry count: ${log.values.length})`)
+      queriesPerSecond = 0
+
+      if (seconds % waveLength === 0) {
+        console.log(`--> Average of ${lastTenSeconds / 10} q/s in this wave`)
+        if (lastTenSeconds === 0) throw new Error('Problems!')
+        lastTenSeconds = 0
+        clearImmediate(immediate)
+        clearInterval(interval)
+        nextWave()
+      }
+    }
+
+    // Output metrics at 1 second interval
+    let interval = setInterval(outputMetrics, 1000)
+    immediate = setImmediate(queryLoop)
+  })
+})()
+
+module.exports = run

--- a/benchmarks/benchmark-has-plus.js
+++ b/benchmarks/benchmark-has-plus.js
@@ -20,16 +20,17 @@ let immediate
 
 let waveCount = 0
 let waveLength = 10 // seconds
+let waveDepth = parseInt(process.argv[2], 10) || 10000
 
 let addEntries = async () => {
-  for (let i=0; i<10000; i++) {
+  for (let i=0; i<waveDepth; i++) {
     await log.append(`Hello World: ${i}`)
   }
 
   // choose random entry
   entry = log.values[Math.floor(Math.random() * log.values.length)]
 
-  console.log(`=== Running wave #${waveCount} for ${waveLength} seconds  with ${log.values.length} entries ===`)
+  console.log(`=== Running wave #${waveCount} for ${waveLength} seconds with ${log.values.length} entries ===`)
 }
 
 const queryLoop = async () => {

--- a/benchmarks/benchmark-has.js
+++ b/benchmarks/benchmark-has.js
@@ -1,0 +1,73 @@
+'use strict'
+
+const Log = require('../src/log')
+const IPFS = require('ipfs')
+const IPFSRepo = require('ipfs-repo')
+const DatastoreLevel = require('datastore-level')
+
+// State
+let ipfs
+let log
+
+// Metrics
+let totalQueries = 0
+let seconds = 0
+let queriesPerSecond = 0
+let lastTenSeconds = 0
+
+let entry
+
+const queryLoop = async () => {
+  log.has(entry.hash)
+  totalQueries++
+  lastTenSeconds++
+  queriesPerSecond++
+  setImmediate(queryLoop)
+}
+
+let run = (() => {
+  console.log('Starting benchmark...')
+
+  const repoConf = {
+    storageBackends: {
+      blocks: DatastoreLevel
+    }
+  }
+
+  ipfs = new IPFS({
+    repo: new IPFSRepo('./ipfs-log-benchmarks/ipfs', repoConf),
+    start: false,
+    EXPERIMENTAL: {
+      pubsub: false,
+      sharding: false,
+      dht: false,
+    },
+  })
+
+  ipfs.on('error', (err) => {
+    console.error(err)
+  })
+
+  ipfs.on('ready', async () => {
+    // Create a log
+    log = new Log(ipfs, 'A')
+
+    entry = await log.append('Hello World')
+
+    // Output metrics at 1 second interval
+    setInterval(() => {
+      seconds++
+      if (seconds % 10 === 0) {
+        console.log(`--> Average of ${lastTenSeconds / 10} q/s in the last 10 seconds`)
+        if (lastTenSeconds === 0) throw new Error('Problems!')
+        lastTenSeconds = 0
+      }
+      console.log(`${queriesPerSecond} queries per second, ${totalQueries} queries in ${seconds} seconds (Entry count: ${log.values.length})`)
+      queriesPerSecond = 0
+    }, 1000)
+
+    setImmediate(queryLoop)
+  })
+})()
+
+module.exports = run

--- a/benchmarks/benchmark-values-plus.js
+++ b/benchmarks/benchmark-values-plus.js
@@ -1,0 +1,108 @@
+'use strict'
+
+const Log = require('../src/log')
+const IPFS = require('ipfs')
+const IPFSRepo = require('ipfs-repo')
+const DatastoreLevel = require('datastore-level')
+
+// State
+let ipfs
+let log
+
+// Metrics
+let totalQueries = 0
+let seconds = 0
+let queriesPerSecond = 0
+let lastTenSeconds = 0
+
+let entry
+let immediate
+
+let waveCount = 0
+let waveLength = 10 // seconds
+
+let addEntries = async () => {
+  for (let i=0; i<10000; i++) {
+    await log.append(`Hello World: ${i}`)
+  }
+
+  // choose random entry
+  entry = log.values[Math.floor(Math.random() * log.values.length)]
+
+  console.log(`=== Running wave #${waveCount} for ${waveLength} seconds  with ${log.values.length} entries ===`)
+}
+
+const queryLoop = async () => {
+  log.values
+  totalQueries++
+  lastTenSeconds++
+  queriesPerSecond++
+  immediate = setImmediate(queryLoop)
+}
+
+let run = (() => {
+  console.log('Starting benchmark...')
+
+  const repoConf = {
+    storageBackends: {
+      blocks: DatastoreLevel
+    }
+  }
+
+  ipfs = new IPFS({
+    repo: new IPFSRepo('./ipfs-log-benchmarks/ipfs', repoConf),
+    start: false,
+    EXPERIMENTAL: {
+      pubsub: false,
+      sharding: false,
+      dht: false,
+    },
+  })
+
+  ipfs.on('error', (err) => {
+    console.error(err)
+  })
+
+  ipfs.on('ready', async () => {
+    // Create a log
+    log = new Log(ipfs, 'A')
+
+    await addEntries()
+
+    const nextWave = async () => {
+      //reset counters
+      totalQueries = 0
+      seconds = 0
+      queriesPerSecond = 0
+      lastTenSeconds = 0
+
+      waveCount++
+      await addEntries()
+
+      interval = setInterval(outputMetrics, 1000)
+      immediate = setImmediate(queryLoop)
+    }
+
+    const outputMetrics = () => {
+      seconds++
+
+      console.log(`${queriesPerSecond} queries per second, ${totalQueries} queries in ${seconds} seconds (Entry count: ${log.values.length})`)
+      queriesPerSecond = 0
+
+      if (seconds % waveLength === 0) {
+        console.log(`--> Average of ${lastTenSeconds / 10} q/s in this wave`)
+        if (lastTenSeconds === 0) throw new Error('Problems!')
+        lastTenSeconds = 0
+        clearImmediate(immediate)
+        clearInterval(interval)
+        nextWave()
+      }
+    }
+
+    // Output metrics at 1 second interval
+    let interval = setInterval(outputMetrics, 1000)
+    immediate = setImmediate(queryLoop)
+  })
+})()
+
+module.exports = run

--- a/benchmarks/benchmark-values-plus.js
+++ b/benchmarks/benchmark-values-plus.js
@@ -20,16 +20,17 @@ let immediate
 
 let waveCount = 0
 let waveLength = 10 // seconds
+let waveDepth = parseInt(process.argv[2], 10) || 10000
 
 let addEntries = async () => {
-  for (let i=0; i<10000; i++) {
+  for (let i=0; i<waveDepth; i++) {
     await log.append(`Hello World: ${i}`)
   }
 
   // choose random entry
   entry = log.values[Math.floor(Math.random() * log.values.length)]
 
-  console.log(`=== Running wave #${waveCount} for ${waveLength} seconds  with ${log.values.length} entries ===`)
+  console.log(`=== Running wave #${waveCount} for ${waveLength} seconds with ${log.values.length} entries ===`)
 }
 
 const queryLoop = async () => {

--- a/benchmarks/benchmark-values.js
+++ b/benchmarks/benchmark-values.js
@@ -1,0 +1,73 @@
+'use strict'
+
+const Log = require('../src/log')
+const IPFS = require('ipfs')
+const IPFSRepo = require('ipfs-repo')
+const DatastoreLevel = require('datastore-level')
+
+// State
+let ipfs
+let log
+
+// Metrics
+let totalQueries = 0
+let seconds = 0
+let queriesPerSecond = 0
+let lastTenSeconds = 0
+
+let entry
+
+const queryLoop = async () => {
+  log.values
+  totalQueries++
+  lastTenSeconds++
+  queriesPerSecond++
+  setImmediate(queryLoop)
+}
+
+let run = (() => {
+  console.log('Starting benchmark...')
+
+  const repoConf = {
+    storageBackends: {
+      blocks: DatastoreLevel
+    }
+  }
+
+  ipfs = new IPFS({
+    repo: new IPFSRepo('./ipfs-log-benchmarks/ipfs', repoConf),
+    start: false,
+    EXPERIMENTAL: {
+      pubsub: false,
+      sharding: false,
+      dht: false,
+    },
+  })
+
+  ipfs.on('error', (err) => {
+    console.error(err)
+  })
+
+  ipfs.on('ready', async () => {
+    // Create a log
+    log = new Log(ipfs, 'A')
+
+    entry = await log.append('Hello World')
+
+    // Output metrics at 1 second interval
+    setInterval(() => {
+      seconds++
+      if (seconds % 10 === 0) {
+        console.log(`--> Average of ${lastTenSeconds / 10} q/s in the last 10 seconds`)
+        if (lastTenSeconds === 0) throw new Error('Problems!')
+        lastTenSeconds = 0
+      }
+      console.log(`${queriesPerSecond} queries per second, ${totalQueries} queries in ${seconds} seconds (Entry count: ${log.values.length})`)
+      queriesPerSecond = 0
+    }, 1000)
+
+    setImmediate(queryLoop)
+  })
+})()
+
+module.exports = run


### PR DESCRIPTION
Two sets of benchmarks for `log.values`, `log.has()`, `log.get()`. 

Interesting results for the `log.values` benchmark with waves.

`~60%` drop in throughput from the initial wave (1000 entries -> 2000 entries). By wave no. 3 (4000 entries), it is down `~83%` from the initial wave. By wave no. 14 (150000 entries), it starts to level off at `~97%` drop from initial wave.

Machine: MacBook Pro (Mid 2012) / 2.6 GHz Intel Core i7 / 16 GB 1600 MHz DDR3

Related: orbitdb/ipfs-log#136