### PR TITLE
test: add benchmark for log.fromEntryHash()

### DIFF
--- a/benchmarks/benchmark-from-entry-hash.js
+++ b/benchmarks/benchmark-from-entry-hash.js
@@ -65,7 +65,6 @@ let run = (() => {
     }
 
     const onDataUpdated = (hash, entry, resultLength, result, queue) => {
-      // totalQueries = resultLength
       queriesPerSecond++
       lastTenSeconds++
       total = resultLength
@@ -73,7 +72,6 @@ let run = (() => {
     }
 
     const outputMetrics = () => {
-      // queriesPerSecond = total - queriesPerSecond
       totalQueries = total - totalQueries
       seconds++
       if (seconds % 10 === 0) {
@@ -107,9 +105,6 @@ let run = (() => {
       onDataUpdated
     )
 
-    // total = result.length
-    // queriesPerSecond = result.length
-    // queriesPerSecond = totalQueries - queriesPerSecond
     outputMetrics()
     const et = new Date().getTime()
     console.log("Loading took:", (et - dt2), "ms")

--- a/benchmarks/benchmark-from-entry-hash.js
+++ b/benchmarks/benchmark-from-entry-hash.js
@@ -94,6 +94,8 @@ let run = (() => {
       console.warn('Start benchmark with --expose-gc flag');
     }
 
+    const m1 = process.memoryUsage()
+
     const result = await Log.fromEntryHash(
       ipfs,
       log.heads.map(e => e.hash),
@@ -108,9 +110,19 @@ let run = (() => {
     outputMetrics()
     const et = new Date().getTime()
     console.log("Loading took:", (et - dt2), "ms")
-    const memory = process.memoryUsage()
-    console.log(`Memory Heap Used: ${memory.heapUsed / 1024 / 1024} MB`)
-    console.log(`Memory Heap Total: ${memory.heapTotal / 1024 / 1024} MB`)
+
+    const m2 = process.memoryUsage()
+    const usedDelta = m1.heapUsed && Math.abs(m1.heapUsed - m2.heapUsed) / m1.heapUsed * 100
+    const totalDelta = m1.heapTotal && Math.abs(m1.heapTotal - m2.heapTotal) / m1.heapTotal * 100
+
+    let usedOutput = `Memory Heap Used: ${(m2.heapUsed / 1024 / 1024).toFixed(2)} MB`
+    usedOutput += ` (${m2.heapUsed > m1.heapUsed ? '+' : '-'}${usedDelta.toFixed(2)}%)`
+    let totalOutput = `Memory Heap Total: ${(m2.heapTotal / 1024 / 1024).toFixed(2)} MB`
+    totalOutput += ` (${m2.heapTotal > m1.heapTotal ? '+' : '-'}${totalDelta.toFixed(2)}%)`
+
+    console.log(usedOutput)
+    console.log(totalOutput)
+
     process.exit(0)
   })
 })()

--- a/benchmarks/benchmark-from-entry-hash.js
+++ b/benchmarks/benchmark-from-entry-hash.js
@@ -22,8 +22,8 @@ let run = (() => {
 
   const repoConf = {
     storageBackends: {
-      blocks: DatastoreLevel,
-    },
+      blocks: DatastoreLevel
+    }
   }
 
   ipfs = new IPFS({
@@ -32,8 +32,8 @@ let run = (() => {
     EXPERIMENTAL: {
       pubsub: false,
       sharding: false,
-      dht: false,
-    },
+      dht: false
+    }
   })
 
   ipfs.on('error', (err) => {
@@ -54,16 +54,15 @@ let run = (() => {
     const st = new Date().getTime()
 
     try {
-    for (let i = 1; i < count + 1; i ++) {
-      await log.append('hello' + i, refCount)
-      process.stdout.write("\rWriting " + i + " / " + count)
-    }
-    const dt1 = new Date().getTime()
+      for (let i = 1; i < count + 1; i ++) {
+        await log.append('hello' + i, refCount)
+        process.stdout.write("\rWriting " + i + " / " + count)
+      }
+      const dt1 = new Date().getTime()
       process.stdout.write(" (" + (dt1 - st) + " ms)\n")
     } catch (e) {
       console.log(e)
     }
-
 
     const onDataUpdated = (hash, entry, resultLength, result, queue) => {
       // totalQueries = resultLength

--- a/benchmarks/benchmark-from-entry-hash.js
+++ b/benchmarks/benchmark-from-entry-hash.js
@@ -11,9 +11,9 @@ let ipfs
 let log
 
 // Metrics
-let totalQueries = 0
+let totalLoaded = 0
 let seconds = 0
-let queriesPerSecond = 0
+let entriesLoadedPerSecond = 0
 let lastTenSeconds = 0
 let total = 0
 
@@ -65,22 +65,22 @@ let run = (() => {
     }
 
     const onDataUpdated = (hash, entry, resultLength, result, queue) => {
-      queriesPerSecond++
+      entriesLoadedPerSecond++
       lastTenSeconds++
       total = resultLength
       process.stdout.write("\rLoading " + total + " / " + count)
     }
 
     const outputMetrics = () => {
-      totalQueries = total - totalQueries
+      totalLoaded = total - totalLoaded
       seconds++
       if (seconds % 10 === 0) {
-        console.log(`--> Average of ${lastTenSeconds / 10} q/s in the last 10 seconds`)
+        console.log(`--> Average of ${lastTenSeconds / 10} e/s in the last 10 seconds`)
         if (lastTenSeconds === 0) throw new Error('Problems!')
         lastTenSeconds = 0
       }
-      console.log(`\n${queriesPerSecond} queries per second, ${totalQueries} queries in ${seconds} seconds (Entry count: ${total})`)
-      queriesPerSecond = 0
+      console.log(`\n${entriesLoadedPerSecond} entries loaded per second, ${totalLoaded} loaded in ${seconds} seconds (Entry count: ${total})`)
+      entriesLoadedPerSecond = 0
     }
 
     // Output metrics at 1 second interval

--- a/benchmarks/benchmark-from-entry-hash.js
+++ b/benchmarks/benchmark-from-entry-hash.js
@@ -1,0 +1,124 @@
+'use strict'
+
+const Log = require('../src/log')
+const EntryIO = require('../src/entry-io')
+const IPFS = require('ipfs')
+const IPFSRepo = require('ipfs-repo')
+const DatastoreLevel = require('datastore-level')
+
+// State
+let ipfs
+let log
+
+// Metrics
+let totalQueries = 0
+let seconds = 0
+let queriesPerSecond = 0
+let lastTenSeconds = 0
+let total = 0
+
+let run = (() => {
+  console.log('Starting benchmark...')
+
+  const repoConf = {
+    storageBackends: {
+      blocks: DatastoreLevel,
+    },
+  }
+
+  ipfs = new IPFS({
+    repo: new IPFSRepo('./ipfs-log-benchmarks/fromEntryHash/ipfs', repoConf),
+    start: false,
+    EXPERIMENTAL: {
+      pubsub: false,
+      sharding: false,
+      dht: false,
+    },
+  })
+
+  ipfs.on('error', (err) => {
+    console.error(err)
+  })
+
+  ipfs.on('ready', async () => {
+    // Create a log
+    log = new Log(ipfs, 'A')
+
+    const count = parseInt(process.argv[2]) || 50000
+    const refCount = 64
+    const concurrency = 128
+    const delay = 0
+
+    console.log("Creating a log...")
+
+    const st = new Date().getTime()
+
+    try {
+    for (let i = 1; i < count + 1; i ++) {
+      await log.append('hello' + i, refCount)
+      process.stdout.write("\rWriting " + i + " / " + count)
+    }
+    const dt1 = new Date().getTime()
+      process.stdout.write(" (" + (dt1 - st) + " ms)\n")
+    } catch (e) {
+      console.log(e)
+    }
+
+
+    const onDataUpdated = (hash, entry, resultLength, result, queue) => {
+      // totalQueries = resultLength
+      queriesPerSecond++
+      lastTenSeconds++
+      total = resultLength
+      process.stdout.write("\rLoading " + total + " / " + count)
+    }
+
+    const outputMetrics = () => {
+      // queriesPerSecond = total - queriesPerSecond
+      totalQueries = total - totalQueries
+      seconds++
+      if (seconds % 10 === 0) {
+        console.log(`--> Average of ${lastTenSeconds / 10} q/s in the last 10 seconds`)
+        if (lastTenSeconds === 0) throw new Error('Problems!')
+        lastTenSeconds = 0
+      }
+      console.log(`\n${queriesPerSecond} queries per second, ${totalQueries} queries in ${seconds} seconds (Entry count: ${total})`)
+      queriesPerSecond = 0
+    }
+
+    // Output metrics at 1 second interval
+    setInterval(outputMetrics, 1000)
+
+    const dt2 = new Date().getTime()
+
+    if (global.gc) {
+      global.gc()
+    } else {
+      console.warn('Start benchmark with --expose-gc flag');
+    }
+
+    const result = await Log.fromEntryHash(
+      ipfs,
+      log.heads.map(e => e.hash),
+      log._id,
+      -1,
+      [],
+      log._key,
+      log._keys,
+      onDataUpdated
+    )
+
+    // total = result.length
+    // queriesPerSecond = result.length
+    // queriesPerSecond = totalQueries - queriesPerSecond
+    outputMetrics()
+    const et = new Date().getTime()
+    console.log("Loading took:", (et - dt2), "ms")
+    const memory = process.memoryUsage()
+    console.log(`Memory Heap Used: ${memory.heapUsed / 1024 / 1024} MB`)
+    console.log(`Memory Heap Total: ${memory.heapTotal / 1024 / 1024} MB`)
+    process.exit(0)
+  })
+})()
+
+module.exports = run


### PR DESCRIPTION
Let me know if you prefer consolidating these benchmarks to one PR.

Also, let me know if you have any suggestions on how to approach memory heap usage profiling. 

Related: orbitdb/ipfs-log#136