### PR TITLE
Add browser example lib directory to linting excludes

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 dist/**
 lib/**
 examples/browser/bundle.js
+examples/browser/lib/**


### PR DESCRIPTION
This PR will add `examples/browser/lib/` to eslint ignore file so that the lib files in examples don't get linted.