### PR TITLE
Fix tests catching errors

### DIFF
--- a/test/entry.spec.js
+++ b/test/entry.spec.js
@@ -115,43 +115,53 @@ apis.forEach((IPFS) => {
       })
 
       it('throws an error if ipfs is not defined', async () => {
+        let err
         try {
           await Entry.create() // eslint-disable-line no-unused-
         } catch (e) {
-          assert.strictEqual(e.message, 'Ipfs instance not defined')
+          err = e
         }
+        assert.strictEqual(err.message, 'Ipfs instance not defined')
       })
 
       it('throws an error if identity are not defined', async () => {
+        let err
         try {
           await Entry.create(ipfs, null, 'A', 'hello2', [])
         } catch (e) {
-          assert.strictEqual(e.message, 'Identity is required, cannot create entry')
+          err = e
         }
+        assert.strictEqual(err.message, 'Identity is required, cannot create entry')
       })
 
       it('throws an error if id is not defined', async () => {
+        let err
         try {
           await Entry.create(ipfs, testIdentity, null, 'hello', [])
         } catch (e) {
-          assert.strictEqual(e.message, 'Entry requires an id')
+          err = e
         }
+        assert.strictEqual(err.message, 'Entry requires an id')
       })
 
       it('throws an error if data is not defined', async () => {
+        let err
         try {
           await Entry.create(ipfs, testIdentity, 'A', null, [])
         } catch (e) {
-          assert.strictEqual(e.message, 'Entry requires data')
+          err = e
         }
+        assert.strictEqual(err.message, 'Entry requires data')
       })
 
       it('throws an error if next is not an array', async () => {
+        let err
         try {
-          await Entry.create(ipfs, testIdentity, 'A', 'hello')
+          await Entry.create(ipfs, testIdentity, 'A', 'hello', {})
         } catch (e) {
-          assert.strictEqual(e.message, '\'next\' argument is not an array')
+          err = e
         }
+        assert.strictEqual(err.message, '\'next\' argument is not an array')
       })
     })
 
@@ -165,27 +175,33 @@ apis.forEach((IPFS) => {
       })
 
       it('throws an error if ipfs is not defined', async () => {
+        let err
         try {
           await Entry.toMultihash()
         } catch (e) {
-          assert.strictEqual(e.message, 'Ipfs instance not defined')
+          err = e
         }
+        assert.strictEqual(err.message, 'Ipfs instance not defined')
       })
 
       it('throws an error if the object being passed is invalid', async () => {
+        let err1, err2
         try {
           await Entry.toMultihash(ipfs, testACL, testIdentity, { hash: 'deadbeef' })
         } catch (e) {
-          assert.strictEqual(e.message, 'Invalid object format, cannot generate entry multihash')
+          err1 = e
         }
+
+        assert.strictEqual(err1.message, 'Invalid object format, cannot generate entry multihash')
 
         try {
           const entry = await Entry.create(ipfs, testIdentity, 'A', 'hello', [])
           delete entry.clock
           await Entry.toMultihash(ipfs, entry)
         } catch (e) {
-          assert.strictEqual(e.message, 'Invalid object format, cannot generate entry multihash')
+          err2 = e
         }
+        assert.strictEqual(err2.message, 'Invalid object format, cannot generate entry multihash')
       })
     })
 
@@ -205,19 +221,23 @@ apis.forEach((IPFS) => {
       })
 
       it('throws an error if ipfs is not present', async () => {
+        let err
         try {
           await Entry.fromMultihash()
         } catch (e) {
-          assert.strictEqual(e.message, 'Ipfs instance not defined')
+          err = e
         }
+        assert.strictEqual(err.message, 'Ipfs instance not defined')
       })
 
       it('throws an error if hash is undefined', async () => {
+        let err
         try {
           await Entry.fromMultihash(ipfs)
         } catch (e) {
-          assert.strictEqual(e.message, 'Invalid hash: undefined')
+          err = e
         }
+        assert.strictEqual(err.message, 'Invalid hash: undefined')
       })
     })
 


### PR DESCRIPTION
This PR will fix the tests where we test catching errors.

These were modified at some point during the acl or linting PRs and I didn't notice the changes in the review :/

As they are now, the tests are not actually catching the errors correctly:
```javascript
it('throws an error if ipfs is not defined', async () => {
  try {
    await Entry.create() // eslint-disable-line no-unused-
  } catch (e) {
    assert.strictEqual(e.message, 'Ipfs instance not defined')
    // if an error wasn't throw, we never assert and the test will pass incorrectly
   }
  // we can end up here if no error was thrown, thus nothing is asserted and tested
})
```

To fix it, for all tests catching errors, they need to be:
```javascript
it('throws an error if ipfs is not defined', async () => {
  let err
  try {
   await Entry.create()
  } catch (e) {
    // catch the error and save it for the asserts after try/catch block
    err = e
  }
  // if an error wasn't thrown, err === undefined and this will throw
  // if an error was thrown, we check that it was the correct error message
  assert.strictEqual(err.message, 'Ipfs instance not defined')
})
```
