### PR TITLE
Update tests to use latest identity-provider (signatures field)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -214,7 +214,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "ammo": {
       "version": "2.0.4",
@@ -2227,10 +2228,13 @@
       }
     },
     "convert-source-map": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-      "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
-      "dev": true
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+      "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.1"
+      }
     },
     "cookie": {
       "version": "0.3.1",
@@ -5216,23 +5220,17 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
-      "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.12.tgz",
+      "integrity": "sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==",
       "dev": true,
       "requires": {
-        "async": "^1.4.0",
+        "async": "^2.5.0",
         "optimist": "^0.6.1",
-        "source-map": "^0.4.4",
-        "uglify-js": "^2.6"
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4"
       },
       "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-          "dev": true
-        },
         "optimist": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
@@ -5244,13 +5242,10 @@
           }
         },
         "source-map": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true,
-          "requires": {
-            "amdefine": ">=0.0.4"
-          }
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
         },
         "wordwrap": {
           "version": "0.0.3",
@@ -9226,9 +9221,9 @@
       }
     },
     "multicast-dns": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.0.1.tgz",
-      "integrity": "sha512-jx8bO2QZvx5oJXWhiuEb6I8XgufpPXvKFSAoSvurD2nECVhbQQTilY33IfChreWqhqPgzKZbpgsyHapjnRTnlw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.0.tgz",
+      "integrity": "sha512-Tu2QORGOFANB124NWQ/JTRhMf/ODouVLEuvu5Dz8YWEU55zQgRgFGnBHfIh5PbfNDAuaRl7yLB+pgWhSqVxi2Q==",
       "dev": true,
       "requires": {
         "dns-packet": "^4.0.0",
@@ -9317,9 +9312,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-1.2.2.tgz",
-      "integrity": "sha512-o4eK+NomkjYEn6cN9rImXMz1st/LdRP+tricKyoH834ikDwp/M/PJlYWTd7E7/OhvObzLJpuuVvwjg+jDpD4hA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-1.2.3.tgz",
+      "integrity": "sha512-BAnxAdaihzMoszwhqRy8FPOX+dijs7esUEUYTIQ1KsOSKmCVNYnitAMmBDFxYzA6VQYvuUKw7o2K1AcMBTGzIg==",
       "dev": true
     },
     "nanomatch": {
@@ -9750,7 +9745,7 @@
       "dev": true
     },
     "orbit-db-identity-provider": {
-      "version": "github:orbitdb/orbit-db-identity-provider#082edbecbabdd46e8ca2a781f1142afcf9bec8d0",
+      "version": "github:orbitdb/orbit-db-identity-provider#693ff383f48807a3b3330d9c462662757580c58b",
       "from": "github:orbitdb/orbit-db-identity-provider"
     },
     "orbit-db-keystore": {
@@ -11212,9 +11207,9 @@
       }
     },
     "rxjs": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.1.tgz",
-      "integrity": "sha512-hRVfb1Mcf8rLXq1AZEjYpzBnQbO7Duveu1APXkWRTvqzhmkoQ40Pl2F9Btacx+gJCOqsMiugCGG4I2HPQgJRtA==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.2.tgz",
+      "integrity": "sha512-hV7criqbR0pe7EeL3O66UYVg92IR0XsA97+9y+BWTePK9SKmEI5Qd3Zj6uPnGkNzXsBywBQWTvujPl+1Kn9Zjw==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -12475,56 +12470,22 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "2.8.29",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+      "version": "3.4.9",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
+      "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
       "dev": true,
+      "optional": true,
       "requires": {
-        "source-map": "~0.5.1",
-        "uglify-to-browserify": "~1.0.0",
-        "yargs": "~3.10.0"
+        "commander": "~2.17.1",
+        "source-map": "~0.6.1"
       },
       "dependencies": {
-        "camelcase": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-          "dev": true
-        },
-        "cliui": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true,
-          "requires": {
-            "center-align": "^0.1.1",
-            "right-align": "^0.1.1",
-            "wordwrap": "0.0.2"
-          }
-        },
-        "decamelize": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-          "dev": true
-        },
-        "wordwrap": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-          "dev": true
-        },
-        "yargs": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-          "dev": true,
-          "requires": {
-            "camelcase": "^1.0.2",
-            "cliui": "^2.1.0",
-            "decamelize": "^1.0.0",
-            "window-size": "0.1.0"
-          }
+          "optional": true
         }
       }
     },
@@ -13305,28 +13266,21 @@
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
+        "camelcase": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+          "dev": true
+        },
         "cliui": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
           "dev": true,
           "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wrap-ansi": "^2.0.0"
-          },
-          "dependencies": {
-            "string-width": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-              "dev": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              }
-            }
+            "center-align": "^0.1.1",
+            "right-align": "^0.1.1",
+            "wordwrap": "0.0.2"
           }
         },
         "decamelize": {
@@ -13377,6 +13331,31 @@
             "has-flag": "^2.0.0"
           }
         },
+        "uglify-js": {
+          "version": "2.8.29",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+          "dev": true,
+          "requires": {
+            "source-map": "~0.5.1",
+            "uglify-to-browserify": "~1.0.0",
+            "yargs": "~3.10.0"
+          },
+          "dependencies": {
+            "yargs": {
+              "version": "3.10.0",
+              "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+              "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+              "dev": true,
+              "requires": {
+                "camelcase": "^1.0.2",
+                "cliui": "^2.1.0",
+                "decamelize": "^1.0.0",
+                "window-size": "0.1.0"
+              }
+            }
+          }
+        },
         "uglifyjs-webpack-plugin": {
           "version": "0.4.6",
           "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.6.tgz",
@@ -13387,6 +13366,12 @@
             "uglify-js": "^2.8.29",
             "webpack-sources": "^1.0.1"
           }
+        },
+        "wordwrap": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+          "dev": true
         },
         "y18n": {
           "version": "3.2.1",
@@ -13413,6 +13398,38 @@
             "which-module": "^2.0.0",
             "y18n": "^3.2.1",
             "yargs-parser": "^7.0.0"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+              "dev": true
+            },
+            "cliui": {
+              "version": "3.2.0",
+              "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+              "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+              "dev": true,
+              "requires": {
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wrap-ansi": "^2.0.0"
+              },
+              "dependencies": {
+                "string-width": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                  "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                  "dev": true,
+                  "requires": {
+                    "code-point-at": "^1.0.0",
+                    "is-fullwidth-code-point": "^1.0.0",
+                    "strip-ansi": "^3.0.0"
+                  }
+                }
+              }
+            }
           }
         },
         "yargs-parser": {
@@ -13422,6 +13439,14 @@
           "dev": true,
           "requires": {
             "camelcase": "^4.1.0"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+              "dev": true
+            }
           }
         }
       }

--- a/test/entry.spec.js
+++ b/test/entry.spec.js
@@ -42,7 +42,7 @@ testAPIs.forEach((IPFS) => {
 
     describe('create', () => {
       it('creates a an empty entry', async () => {
-        const expectedHash = 'QmVk4R4ePk7PHhpJ9g212iSzgXodw7bKGacMXLkxDavh9X'
+        const expectedHash = 'QmUZqFJeeh8G9kiLxm8qZjyULoD23Kt9CxaZYH1fbu9Bsr'
         const entry = await Entry.create(ipfs, testIdentity, 'A', 'hello')
         assert.strictEqual(entry.hash, expectedHash)
         assert.strictEqual(entry.id, 'A')
@@ -54,7 +54,7 @@ testAPIs.forEach((IPFS) => {
       })
 
       it('creates a entry with payload', async () => {
-        const expectedHash = 'QmfMKCbcAdoT2UGfKxBTJE9TX7PJoHx4YvYZ6kBHeS3QFz'
+        const expectedHash = 'Qmb4TaBbNb4n6QPbqj1RHfGo6yEJfAzASMWegQGMGhC6oZ'
         const payload = 'hello world'
         const entry = await Entry.create(ipfs, testIdentity, 'A', payload, [])
         assert.strictEqual(entry.payload, payload)
@@ -67,7 +67,7 @@ testAPIs.forEach((IPFS) => {
       })
 
       it('creates a entry with payload and next', async () => {
-        const expectedHash = 'QmfYg1oL42CrugMPhat3sCZ6DRwFLTuqzgFLqQy4fNgP1g'
+        const expectedHash = 'QmdEQdYRQUTuWXphFhAYqQW9NaiwMoVuth2ikyqNP8iY9W'
         const payload1 = 'hello world'
         const payload2 = 'hello again'
         const entry1 = await Entry.create(ipfs, testIdentity, 'A', payload1, [])
@@ -151,7 +151,7 @@ testAPIs.forEach((IPFS) => {
 
     describe('toMultihash', () => {
       it('returns an ipfs hash', async () => {
-        const expectedHash = 'QmVk4R4ePk7PHhpJ9g212iSzgXodw7bKGacMXLkxDavh9X'
+        const expectedHash = 'QmUZqFJeeh8G9kiLxm8qZjyULoD23Kt9CxaZYH1fbu9Bsr'
         const entry = await Entry.create(ipfs, testIdentity, 'A', 'hello', [])
         const hash = await Entry.toMultihash(ipfs, entry)
         assert.strictEqual(entry.hash, expectedHash)
@@ -191,7 +191,7 @@ testAPIs.forEach((IPFS) => {
 
     describe('fromMultihash', () => {
       it('creates a entry from ipfs hash', async () => {
-        const expectedHash = 'Qmb6jCETr8ARcFHS28BFRXJrdyi1eJEpRenqKGDarrhkvT'
+        const expectedHash = 'QmWatF9kgmtgB9z152QuvRBD6MKa1qWYK6BFV7coKSqgvD'
         const payload1 = 'hello world'
         const payload2 = 'hello again'
         const entry1 = await Entry.create(ipfs, testIdentity, 'A', payload1, [])

--- a/test/log.spec.js
+++ b/test/log.spec.js
@@ -196,7 +196,7 @@ testAPIs.forEach((IPFS) => {
 
       it('returns an Entry', () => {
         const entry = log.get(log.values[0].hash)
-        assert.deepStrictEqual(entry.hash, 'QmVRpSH5Tq9zX7HNUHaVsuct69CihanpAptqF9dRmybTcJ')
+        assert.deepStrictEqual(entry.hash, 'QmbrkSuBPRkcwgoaFNwReKKgpxsRRqvu1VjRE2A5anbXVF')
       })
 
       it('returns undefined when Entry is not in the log', () => {
@@ -210,7 +210,7 @@ testAPIs.forEach((IPFS) => {
 
       before(async () => {
         expectedData = {
-          hash: 'QmVRpSH5Tq9zX7HNUHaVsuct69CihanpAptqF9dRmybTcJ',
+          hash: 'QmbrkSuBPRkcwgoaFNwReKKgpxsRRqvu1VjRE2A5anbXVF',
           id: 'AAA',
           payload: 'one',
           next: [],
@@ -244,7 +244,7 @@ testAPIs.forEach((IPFS) => {
       let log//, testIdentity2, testIdentity3, testIdentity4
       const expectedData = {
         id: 'AAA',
-        heads: ['QmPtC2HyWQFgP9zAsuomcC7viJhQLXwoBuk72f1hQoGqgQ']
+        heads: ['QmUq4N33J49UMtmVJQ7knzUF31ei8rkAtHpGxKRWhrcvou']
       }
 
       beforeEach(async () => {
@@ -263,11 +263,11 @@ testAPIs.forEach((IPFS) => {
       describe('toSnapshot', () => {
         const expectedData = {
           id: 'AAA',
-          heads: ['QmPtC2HyWQFgP9zAsuomcC7viJhQLXwoBuk72f1hQoGqgQ'],
+          heads: ['QmUq4N33J49UMtmVJQ7knzUF31ei8rkAtHpGxKRWhrcvou'],
           values: [
-            'QmVRpSH5Tq9zX7HNUHaVsuct69CihanpAptqF9dRmybTcJ',
-            'QmVuKMqjch4m6joYMqEM2Qr7WKkFY9jZ3SvQZu3jcSRqck',
-            'QmPtC2HyWQFgP9zAsuomcC7viJhQLXwoBuk72f1hQoGqgQ'
+            'QmbrkSuBPRkcwgoaFNwReKKgpxsRRqvu1VjRE2A5anbXVF',
+            'QmQDwgHCqNgnKKurqV9LHfvrC7WmSaohbq6i3EyE34KHpA',
+            'QmUq4N33J49UMtmVJQ7knzUF31ei8rkAtHpGxKRWhrcvou'
           ]
         }
 
@@ -291,7 +291,7 @@ testAPIs.forEach((IPFS) => {
 
       describe('toMultihash', async () => {
         it('returns the log as ipfs hash', async () => {
-          const expectedHash = 'QmTkwV5BwuEpQNV2TLpvfsodqvkdqqXMWuNkaaAgFTYxkB'
+          const expectedHash = 'QmNgNFhPLFcMWfVfHKuksTguHPj8VZSiQca2N3aJieB7aZ'
           let log = new Log(ipfs, testACL, testIdentity, 'A')
           await log.append('one')
           const hash = await log.toMultihash()
@@ -301,9 +301,9 @@ testAPIs.forEach((IPFS) => {
         it('log serialized to ipfs contains the correct data', async () => {
           const expectedData = {
             id: 'A',
-            heads: ['QmYaoNpasjTXyEdnBezvFCyjuynAygzqveURK95MTCdbwh']
+            heads: ['QmSkv7dzQcrk5ysF53XkwzTKMgpgRzsCrN4t4hBHgUPM2Y']
           }
-          const expectedHash = 'QmTkwV5BwuEpQNV2TLpvfsodqvkdqqXMWuNkaaAgFTYxkB'
+          const expectedHash = 'QmNgNFhPLFcMWfVfHKuksTguHPj8VZSiQca2N3aJieB7aZ'
           let log = new Log(ipfs, testACL, testIdentity, 'A')
           await log.append('one')
           const hash = await log.toMultihash()
@@ -330,7 +330,7 @@ testAPIs.forEach((IPFS) => {
         it('creates a log from ipfs hash - one entry', async () => {
           const expectedData = {
             id: 'X',
-            heads: ['Qmdw8hTMzVnG4VTYRN61VPcomrDGw244co26Jid7j4WDJ7']
+            heads: ['Qme3Cd5J2cqBZT1mGZ8LPoKAenjKNiowx9usUpNKoatv1p']
           }
           let log = new Log(ipfs, testACL, testIdentity, 'X')
           await log.append('one')

--- a/test/signed-log.spec.js
+++ b/test/signed-log.spec.js
@@ -51,8 +51,8 @@ testAPIs.forEach((IPFS) => {
       assert.notStrictEqual(log.id, null)
       assert.strictEqual(log._identity.id, 'userA')
       assert.strictEqual(log._identity.publicKey, '042750228c5d81653e5142e6a56d5551231649160f77b25797dc427f8a5b2afd650acca10182f0dfc519dc6d6e5216b9a6612dbfc56e906bdbf34ea373c92b30d7')
-      assert.strictEqual(log._identity.pkSignature, '30440220590c0b1a84d5edabf4238ea924ad06481a47ba7f866d88d5950e89ee53670d04022068896f4d850297051c6b1acd5edb8d9dacc0a8fa3d11f436b79e193d14236a05')
-      assert.strictEqual(log._identity.signature, '304502210083bee84a2ecab7df452e0642b5d6f84ecc1c33927eac26049111bea64dfc0b8102202ef96123734077f171e211f21f632006a7cdce9d5757ea7c4edd4d54eadbe5d4')
+      assert.strictEqual(log._identity.signatures.id, '30440220590c0b1a84d5edabf4238ea924ad06481a47ba7f866d88d5950e89ee53670d04022068896f4d850297051c6b1acd5edb8d9dacc0a8fa3d11f436b79e193d14236a05')
+      assert.strictEqual(log._identity.signatures.publicKey, '304502210083bee84a2ecab7df452e0642b5d6f84ecc1c33927eac26049111bea64dfc0b8102202ef96123734077f171e211f21f632006a7cdce9d5757ea7c4edd4d54eadbe5d4')
     })
 
     it('has the correct public key', () => {
@@ -62,12 +62,12 @@ testAPIs.forEach((IPFS) => {
 
     it('has the correct pkSignature', () => {
       const log = new Log(ipfs, testACL, testIdentity, 'A')
-      assert.strictEqual(log._identity.pkSignature, testIdentity.pkSignature)
+      assert.strictEqual(log._identity.signatures.id, testIdentity.signatures.id)
     })
 
     it('has the correct signature', () => {
       const log = new Log(ipfs, testACL, testIdentity, 'A')
-      assert.strictEqual(log._identity.signature, testIdentity.signature)
+      assert.strictEqual(log._identity.signatures.publicKey, testIdentity.signatures.publicKey)
     })
 
     it('entries contain an identity', async () => {


### PR DESCRIPTION
This PR will update the tests to be compatible with the latest version of oribt-db-identity-provider which changes [the field names for the signatures](https://github.com/orbitdb/orbit-db-identity-provider/pull/10).