### PR TITLE
Change order of fields in Entry.to/fromMultihash to match Entry.create

### DIFF
--- a/src/entry.js
+++ b/src/entry.js
@@ -62,7 +62,7 @@ class Entry {
       payload: entry.payload,
       next: entry.next,
       v: entry.v,
-      clock: entry.clock
+      clock: new Clock(entry.clock.id, entry.clock.time)
     })
 
     return identityProvider.verify(entry.sig, entry.key, Entry.toBuffer(e))
@@ -99,9 +99,9 @@ class Entry {
       clock: entry.clock
     }
 
-    if (entry.sig) Object.assign(e, { sig: entry.sig })
-    if (entry.identity) Object.assign(e, { identity: entry.identity })
     if (entry.key) Object.assign(e, { key: entry.key })
+    if (entry.identity) Object.assign(e, { identity: entry.identity })
+    if (entry.sig) Object.assign(e, { sig: entry.sig })
 
     const data = Entry.toBuffer(e)
     const object = await ipfs.object.put(data)
@@ -134,9 +134,9 @@ class Entry {
       clock: new Clock(data.clock.id, data.clock.time)
     }
 
-    if (data.sig) Object.assign(entry, { sig: data.sig })
-    if (data.identity) Object.assign(entry, { identity: data.identity })
     if (data.key) Object.assign(entry, { key: data.key })
+    if (data.identity) Object.assign(entry, { identity: data.identity })
+    if (data.sig) Object.assign(entry, { sig: data.sig })
 
     return entry
   }

--- a/test/entry.spec.js
+++ b/test/entry.spec.js
@@ -38,7 +38,7 @@ testAPIs.forEach((IPFS) => {
 
     describe('create', () => {
       it('creates a an empty entry', async () => {
-        const expectedHash = 'QmXfBCS9492S6eNfFT3J45W7ruFjnqJTre4iXcC5tg913X'
+        const expectedHash = 'QmR4Vvn1NEmManWgnvg8hgS8PR6wuMPGr4roxS8KG9RBqv'
         const entry = await Entry.create(ipfs, testIdentity, 'A', 'hello')
         assert.strictEqual(entry.hash, expectedHash)
         assert.strictEqual(entry.id, 'A')
@@ -50,7 +50,7 @@ testAPIs.forEach((IPFS) => {
       })
 
       it('creates a entry with payload', async () => {
-        const expectedHash = 'QmVPLSEsaiypMFtaZEPwGp3mEfkdwmRPGj86MvgYi6XX6m'
+        const expectedHash = 'QmRznMRXh3fBA3sXyjEzgzGYgehVFhmLG5VDsZZnszENsC'
         const payload = 'hello world'
         const entry = await Entry.create(ipfs, testIdentity, 'A', payload, [])
         assert.strictEqual(entry.payload, payload)
@@ -63,7 +63,7 @@ testAPIs.forEach((IPFS) => {
       })
 
       it('creates a entry with payload and next', async () => {
-        const expectedHash = 'Qmein7z1H9ECfHZ2ZoNYeLZBGvYuR35efcWYopCywqHy5Q'
+        const expectedHash = 'QmYxZ8QBaRMNgHHdMfnizgYxsj9hvcqf9MaiJxDaSGvBjz'
         const payload1 = 'hello world'
         const payload2 = 'hello again'
         const entry1 = await Entry.create(ipfs, testIdentity, 'A', payload1, [])
@@ -147,7 +147,7 @@ testAPIs.forEach((IPFS) => {
 
     describe('toMultihash', () => {
       it('returns an ipfs hash', async () => {
-        const expectedHash = 'QmXfBCS9492S6eNfFT3J45W7ruFjnqJTre4iXcC5tg913X'
+        const expectedHash = 'QmR4Vvn1NEmManWgnvg8hgS8PR6wuMPGr4roxS8KG9RBqv'
         const entry = await Entry.create(ipfs, testIdentity, 'A', 'hello', [])
         const hash = await Entry.toMultihash(ipfs, entry)
         assert.strictEqual(entry.hash, expectedHash)
@@ -187,7 +187,7 @@ testAPIs.forEach((IPFS) => {
 
     describe('fromMultihash', () => {
       it('creates a entry from ipfs hash', async () => {
-        const expectedHash = 'QmVDZw6kFVnfBur62cdjJvypP7E8xuJ9mGb2fScBapdqe9'
+        const expectedHash = 'QmYLck98RqCVSQtd3prfZiCnUhCsyKQmN6LR1ivYfAoQBV'
         const payload1 = 'hello world'
         const payload2 = 'hello again'
         const entry1 = await Entry.create(ipfs, testIdentity, 'A', payload1, [])

--- a/test/log.spec.js
+++ b/test/log.spec.js
@@ -196,7 +196,7 @@ testAPIs.forEach((IPFS) => {
 
       it('returns an Entry', () => {
         const entry = log.get(log.values[0].hash)
-        assert.deepStrictEqual(entry.hash, 'QmbrkSuBPRkcwgoaFNwReKKgpxsRRqvu1VjRE2A5anbXVF')
+        assert.deepStrictEqual(entry.hash, 'QmV6wRY2iwXVNYBj4Kg6ZS47wKPQRGzDiQeNpReh6KT8uB')
       })
 
       it('returns undefined when Entry is not in the log', () => {
@@ -210,7 +210,7 @@ testAPIs.forEach((IPFS) => {
 
       before(async () => {
         expectedData = {
-          hash: 'QmbrkSuBPRkcwgoaFNwReKKgpxsRRqvu1VjRE2A5anbXVF',
+          hash: 'QmV6wRY2iwXVNYBj4Kg6ZS47wKPQRGzDiQeNpReh6KT8uB',
           id: 'AAA',
           payload: 'one',
           next: [],
@@ -244,7 +244,7 @@ testAPIs.forEach((IPFS) => {
       let log//, testIdentity2, testIdentity3, testIdentity4
       const expectedData = {
         id: 'AAA',
-        heads: ['QmUq4N33J49UMtmVJQ7knzUF31ei8rkAtHpGxKRWhrcvou']
+        heads: ['Qme8KSsbStLx5nBJehZW8yfmf6DWzGsfXtz8a3zm2XTGSv']
       }
 
       beforeEach(async () => {
@@ -263,11 +263,11 @@ testAPIs.forEach((IPFS) => {
       describe('toSnapshot', () => {
         const expectedData = {
           id: 'AAA',
-          heads: ['QmUq4N33J49UMtmVJQ7knzUF31ei8rkAtHpGxKRWhrcvou'],
+          heads: ['Qme8KSsbStLx5nBJehZW8yfmf6DWzGsfXtz8a3zm2XTGSv'],
           values: [
-            'QmbrkSuBPRkcwgoaFNwReKKgpxsRRqvu1VjRE2A5anbXVF',
-            'QmQDwgHCqNgnKKurqV9LHfvrC7WmSaohbq6i3EyE34KHpA',
-            'QmUq4N33J49UMtmVJQ7knzUF31ei8rkAtHpGxKRWhrcvou'
+            'QmV6wRY2iwXVNYBj4Kg6ZS47wKPQRGzDiQeNpReh6KT8uB',
+            'QmbFkHpu4LKjYpGRJcunbQ3Hg5js6dpcGixn49LAZ1dZNF',
+            'Qme8KSsbStLx5nBJehZW8yfmf6DWzGsfXtz8a3zm2XTGSv'
           ]
         }
 
@@ -291,7 +291,7 @@ testAPIs.forEach((IPFS) => {
 
       describe('toMultihash', async () => {
         it('returns the log as ipfs hash', async () => {
-          const expectedHash = 'QmNgNFhPLFcMWfVfHKuksTguHPj8VZSiQca2N3aJieB7aZ'
+          const expectedHash = 'Qmdi7roKm95deGksZdTR37KYgBDrF8imyWx3N2SPowe6DM'
           let log = new Log(ipfs, testACL, testIdentity, 'A')
           await log.append('one')
           const hash = await log.toMultihash()
@@ -301,9 +301,9 @@ testAPIs.forEach((IPFS) => {
         it('log serialized to ipfs contains the correct data', async () => {
           const expectedData = {
             id: 'A',
-            heads: ['QmSkv7dzQcrk5ysF53XkwzTKMgpgRzsCrN4t4hBHgUPM2Y']
+            heads: ['QmYsGig22v2S9Tq96Uc9PvcHgpgUtYozrygiAvdVVmnuwb']
           }
-          const expectedHash = 'QmNgNFhPLFcMWfVfHKuksTguHPj8VZSiQca2N3aJieB7aZ'
+          const expectedHash = 'Qmdi7roKm95deGksZdTR37KYgBDrF8imyWx3N2SPowe6DM'
           let log = new Log(ipfs, testACL, testIdentity, 'A')
           await log.append('one')
           const hash = await log.toMultihash()
@@ -330,7 +330,7 @@ testAPIs.forEach((IPFS) => {
         it('creates a log from ipfs hash - one entry', async () => {
           const expectedData = {
             id: 'X',
-            heads: ['Qme3Cd5J2cqBZT1mGZ8LPoKAenjKNiowx9usUpNKoatv1p']
+            heads: ['QmWewiBMG942b9fki7zCzk9BQPufnAA1gKxZLToGKhTcMX']
           }
           let log = new Log(ipfs, testACL, testIdentity, 'X')
           await log.append('one')


### PR DESCRIPTION
This PR fixes the `Warning! Head hash didn't match the contents` mismatch.