### PR TITLE
Export utils from a single file

### DIFF
--- a/src/entry.js
+++ b/src/entry.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Clock = require('./lamport-clock')
-const isDefined = require('./utils/is-defined')
+const { isDefined } = require('./utils')
 
 const IpfsNotDefinedError = () => new Error('Ipfs instance not defined')
 

--- a/src/log-io.js
+++ b/src/log-io.js
@@ -4,10 +4,7 @@ const Entry = require('./entry')
 const EntryIO = require('./entry-io')
 const Clock = require('./lamport-clock')
 const LogError = require('./log-errors')
-const isDefined = require('./utils/is-defined')
-const _uniques = require('./utils/uniques')
-// const intersection = require('./utils/intersection')
-const difference = require('./utils/difference')
+const { isDefined, findUniques, difference } = require('./utils')
 
 const last = (arr, n) => arr.slice(arr.length - n, arr.length)
 
@@ -120,7 +117,7 @@ class LogIO {
 
     // Combine the fetches with the source entries and take only uniques
     const combined = sourceEntries.concat(entries)
-    const uniques = _uniques(combined, 'hash').sort(Entry.compare)
+    const uniques = findUniques(combined, 'hash').sort(Entry.compare)
 
     // Cap the result at the right size by taking the last n entries
     const sliced = uniques.slice(length > -1 ? -length : -uniques.length)

--- a/src/log.js
+++ b/src/log.js
@@ -6,10 +6,10 @@ const Entry = require('./entry')
 const LogIO = require('./log-io')
 const LogError = require('./log-errors')
 const Clock = require('./lamport-clock')
-const isDefined = require('./utils/is-defined')
-const _uniques = require('./utils/uniques')
 const AccessController = require('./default-access-controller')
 const IdentityProvider = require('orbit-db-identity-provider')
+const { isDefined, findUniques } = require('./utils')
+
 const randomId = () => new Date().getTime().toString()
 const getHash = e => e.hash
 const flatMap = (res, acc) => res.concat(acc)
@@ -511,7 +511,7 @@ class Log extends GSet {
     // Create our indices
     entries.forEach(addToIndex)
 
-    var addUniques = (res, entries, idx, arr) => res.concat(_uniques(entries, 'hash'))
+    var addUniques = (res, entries, idx, arr) => res.concat(findUniques(entries, 'hash'))
     var exists = e => hashes[e] === undefined
     var findFromReverseIndex = e => reverseIndex[e]
 
@@ -522,7 +522,7 @@ class Log extends GSet {
       .reduce(addUniques, []) // Flatten the result and take only uniques
       .concat(nullIndex) // Combine with tails the have no next refs (ie. first-in-their-chain)
 
-    return _uniques(tails, 'hash').sort(Entry.compare)
+    return findUniques(tails, 'hash').sort(Entry.compare)
   }
 
   // Find the hashes to entries that are not in a collection

--- a/src/utils/find-uniques.js
+++ b/src/utils/find-uniques.js
@@ -1,6 +1,6 @@
 'use strict'
 
-function uniques (value, key) {
+function findUniques (value, key) {
   // Create an index of the collection
   let uniques = {}
   var get = e => uniques[e]
@@ -9,4 +9,4 @@ function uniques (value, key) {
   return Object.keys(uniques).map(get)
 }
 
-module.exports = uniques
+module.exports = findUniques

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,0 +1,13 @@
+'use strict'
+
+const difference = require('./difference')
+const findUniques = require('./find-uniques')
+const intersection = require('./intersection')
+const isDefined = require('./is-defined')
+
+module.exports = {
+  difference,
+  findUniques,
+  intersection,
+  isDefined
+}


### PR DESCRIPTION
This PR will refactor utils so that they get exported from a single file and be included in other parts of the code with `const { isDefined, findUniques, difference } = require('./utils')`.

This PR is based on @thiagodelgado111's PR https://github.com/orbitdb/ipfs-log/pull/147.

@thiagodelgado111 instead of rebasing the previous PR (as there's been *a lot* of changes since then), I took the changes and created a new branch as I wanted to get this finished. Hope you don't mind.