### PR TITLE
refactor: immutabledb -> ipfs

### DIFF
--- a/src/log-errors.js
+++ b/src/log-errors.js
@@ -1,11 +1,11 @@
 'use strict'
 
-const ImmutableDBNotDefinedError = () => new Error('ImmutableDB instance not defined')
+const IPFSNotDefinedError = () => new Error('IPFS instance not defined')
 const LogNotDefinedError = () => new Error('Log instance not defined')
 const NotALogError = () => new Error('Given argument is not an instance of Log')
 
 module.exports = {
-  ImmutableDBNotDefinedError: ImmutableDBNotDefinedError,
+  IPFSNotDefinedError: IPFSNotDefinedError,
   LogNotDefinedError: LogNotDefinedError,
   NotALogError: NotALogError
 }

--- a/src/log.js
+++ b/src/log.js
@@ -44,7 +44,7 @@ class Log extends GSet {
    */
   constructor (ipfs, access, identity, logId, entries, heads, clock) {
     if (!isDefined(ipfs)) {
-      throw LogError.ImmutableDBNotDefinedError()
+      throw LogError.IPFSNotDefinedError()
     }
 
     if (!isDefined(access)) {
@@ -394,7 +394,7 @@ class Log extends GSet {
    * @return {Promise<Log>}      New Log
    */
   static async fromMultihash (ipfs, access, identity, hash, length = -1, exclude, onProgressCallback) {
-    if (!isDefined(ipfs)) throw LogError.ImmutableDBNotDefinedError()
+    if (!isDefined(ipfs)) throw LogError.IPFSNotDefinedError()
     if (!isDefined(hash)) throw new Error(`Invalid hash: ${hash}`)
 
     // TODO: need to verify the entries with 'key'
@@ -411,7 +411,7 @@ class Log extends GSet {
    * @return {Promise<Log>}      New Log
    */
   static async fromEntryHash (ipfs, access, identity, hash, id, length = -1, exclude, onProgressCallback) {
-    if (!isDefined(ipfs)) throw LogError.ImmutableDBNotDefinedError()
+    if (!isDefined(ipfs)) throw LogError.IPFSNotDefinedError()
     if (!isDefined(hash)) throw new Error("'hash' must be defined")
 
     // TODO: need to verify the entries with 'key'
@@ -428,7 +428,7 @@ class Log extends GSet {
    * @return {Promise<Log>}      New Log
    */
   static async fromJSON (ipfs, access, identity, json, length = -1, timeout, onProgressCallback) {
-    if (!isDefined(ipfs)) throw LogError.ImmutableDBNotDefinedError()
+    if (!isDefined(ipfs)) throw LogError.IPFSNotDefinedError()
 
     // TODO: need to verify the entries with 'key'
     const data = await LogIO.fromJSON(ipfs, json, length, timeout, onProgressCallback)
@@ -445,7 +445,7 @@ class Log extends GSet {
    * @return {Promise<Log>}       New Log
    */
   static async fromEntry (ipfs, access, identity, sourceEntries, length = -1, exclude, onProgressCallback) {
-    if (!isDefined(ipfs)) throw LogError.ImmutableDBNotDefinedError()
+    if (!isDefined(ipfs)) throw LogError.IPFSNotDefinedError()
     if (!isDefined(sourceEntries)) throw new Error("'sourceEntries' must be defined")
 
     // TODO: need to verify the entries with 'key'

--- a/test/log-load.spec.js
+++ b/test/log-load.spec.js
@@ -632,7 +632,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
           err = e
         }
         assert.notStrictEqual(err, null)
-        assert.strictEqual(err.message, 'ImmutableDB instance not defined')
+        assert.strictEqual(err.message, 'IPFS instance not defined')
       })
 
       describe('fetches a log', () => {

--- a/test/log.spec.js
+++ b/test/log.spec.js
@@ -62,14 +62,14 @@ Object.keys(testAPIs).forEach((IPFS) => {
         assert.deepStrictEqual(log.tails, [])
       })
 
-      it('throws an error if ImmutableDB instance is not passed as an argument', () => {
+      it('throws an error if IPFS instance is not passed as an argument', () => {
         let err
         try {
           const log = new Log() // eslint-disable-line no-unused-vars
         } catch (e) {
           err = e
         }
-        assert.strictEqual(err.message, 'ImmutableDB instance not defined')
+        assert.strictEqual(err.message, 'IPFS instance not defined')
       })
 
       it('sets an id', () => {
@@ -410,7 +410,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
             err = e
           }
           assert.notStrictEqual(err, null)
-          assert.strictEqual(err.message, 'ImmutableDB instance not defined')
+          assert.strictEqual(err.message, 'IPFS instance not defined')
         })
 
         it('throws an error if hash is not defined', async () => {


### PR DESCRIPTION
## Description 

Really minor, to increase code readability and resolve small point of confusion, opened pr instead of issue. Changes` immutabledb` to `ipfs` as the inline docs already specify and as it used elsewhere. If there was an intention for using ` immutabledb`, could open pr to change inline docs instead. 