### PR TITLE
Fixing length bug

### DIFF
--- a/src/log.js
+++ b/src/log.js
@@ -288,7 +288,7 @@ class Log extends GSet {
     this._entryIndex = Object.assign(this._entryIndex, newItems)
 
     // Update the length cache
-    this._length = Object.keys(this._entryIndex).length;
+    this._length = Object.keys(this._entryIndex).length
 
     // Update the internal next pointers index
     const addToNextsIndex = e => e.next.forEach(a => (this._nextsIndex[a] = e.hash))

--- a/src/log.js
+++ b/src/log.js
@@ -57,9 +57,9 @@ class Log extends GSet {
     }
 
     // Backwards compatibility
-    if(Array.isArray(entries)) {
+    if (Array.isArray(entries)) {
       entries = new Set(entries)
-      console.warn("Passing an array of entries to new Log will soon be deprecated. Use Set instead")
+      console.warn('Passing an array of entries to new Log will soon be deprecated. Use Set instead')
     }
 
     if (isDefined(entries) && !(entries instanceof Set)) {
@@ -484,7 +484,7 @@ class Log extends GSet {
    * @param {Array<Entry>} Entries to search heads from
    * @returns {Array<Entry>}
    */
-  //TODO Entries as seet
+  // TODO Entries as seet
   static findHeads (entries) {
     var indexReducer = (res, entry, idx, arr) => {
       var addToResult = e => (res[e] = entry.hash)

--- a/src/log.js
+++ b/src/log.js
@@ -287,12 +287,12 @@ class Log extends GSet {
     // Update the internal entry index
     this._entryIndex = Object.assign(this._entryIndex, newItems)
 
+    // Update the length cache
+    this._length = Object.keys(this._entryIndex).length;
+
     // Update the internal next pointers index
     const addToNextsIndex = e => e.next.forEach(a => (this._nextsIndex[a] = e.hash))
     Object.values(newItems).forEach(addToNextsIndex)
-
-    // Update the length
-    this._length += Object.values(newItems).length
 
     // Slice to the requested size
     if (size > -1) {

--- a/src/log.js
+++ b/src/log.js
@@ -299,7 +299,7 @@ class Log extends GSet {
     this._entryIndex = Object.assign(this._entryIndex, newItems)
 
     // Update the length cache
-    this._length = Object.keys(this._entryIndex).length
+    this._length = Object.keys(this._entryIndex).length;
 
     // Update the internal next pointers index
     const addToNextsIndex = e => e.next.forEach(a => (this._nextsIndex[a] = e.hash))

--- a/test/log.spec.js
+++ b/test/log.spec.js
@@ -128,7 +128,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
           err = e
         }
         assert.notStrictEqual(err, undefined)
-        assert.strictEqual(err.message, `'entries' argument must be an array of Entry instances`)
+        assert.strictEqual(err.message, `'entries' argument must be a Set of Entry instances`)
       })
 
       it('throws an error if heads is not an array', () => {


### PR DESCRIPTION
## Description

Quick PR to fix the replication tests by changing when and how we cache `Log._length`

## Deprecation

This PR deprecates the passing of entry arrays to the `Log` constructor. It will still accept them but the convention should move towards passing a JS `Set`: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set