### PR TITLE
fix: length calculation based on unique additions to the log

### DIFF
--- a/src/log.js
+++ b/src/log.js
@@ -284,15 +284,15 @@ class Log extends GSet {
     await pMap(entriesToJoin, permitted, { concurrency: 1 })
     await pMap(entriesToJoin, verify, { concurrency: 1 })
 
-    // Update the internal entry index
-    this._entryIndex = Object.assign(this._entryIndex, newItems)
-
     // Update the internal next pointers index
-    const addToNextsIndex = e => e.next.forEach(a => (this._nextsIndex[a] = e.hash))
+    const addToNextsIndex = e => {
+      if (!this.get(e.hash)) this._length++
+      e.next.forEach(a => (this._nextsIndex[a] = e.hash))
+    }
     Object.values(newItems).forEach(addToNextsIndex)
 
-    // Update the length
-    this._length += Object.values(newItems).length
+    // Update the internal entry index
+    this._entryIndex = Object.assign(this._entryIndex, newItems)
 
     // Slice to the requested size
     if (size > -1) {


### PR DESCRIPTION
## Description

A better, less expensive fix for the `_length` problem. @haadcode had suggested migrating this to the javascript `Set` primitive and I think that this will be a worthy endeavor to do at a later date. Many of these problems would go away, in addition to all of the required `_*Index` objects