### PR TITLE
Remove Log.expand and Log.expandFrom documentation

### DIFF
--- a/API.md
+++ b/API.md
@@ -153,18 +153,6 @@ Log.isLog('hello')
 // false
 ```
 
-#### Log.expand(ipfs, log, [amount=-1])
-
-Expands a `log` by `amount` by retrieving more entries from the tails of the log. Returns a new `Log` instance. 
-
-Expanding a log will retrieve new entries from IPFS, thus causing side effects.
-
-#### Log.expandFrom(ipfs, log, entries, [amount=-1])
-
-Expand a `log` by `amount` by retrieving more entries starting from `entries`. `entries` is an `Array` of `Entry` instances. Returns a new `Log` instance. 
-
-Expanding a log will retrieve new entries from IPFS, thus causing side effects.
-
 #### Log.fromEntry(ipfs, entry, [length=-1])
 
 Create a `Log` from an `Entry`.


### PR DESCRIPTION
We've removed `Log.expand` and `Log.expandFrom`. This PR will remove them from the API documentation.