### PR TITLE
Add rebuild command to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,4 +19,9 @@ clean:
 	rm -rf coverage/
 	rm -rf test/keystore/
 
+clean-dependencies: clean
+	if [ -a package-lock.json ]; then rm package-lock.json; fi;
+
+rebuild: | clean-dependencies build
+	
 .PHONY: test


### PR DESCRIPTION
This PR will add `rebuild` command to Makefile. `rebuild` will also remove `package-lock.json` when present as to build everything completely from scratch.