### PR TITLE
Fix browser examples

### DIFF
--- a/examples/browser/browser.html
+++ b/examples/browser/browser.html
@@ -8,6 +8,7 @@
 
     <script type="text/javascript" src="../../dist/ipfslog.min.js" charset="utf-8"></script>
     <script type="text/javascript" src="../../node_modules/orbit-db-keystore/dist/index-browser.min.js" charset="utf-8"></script>
+    <script type="text/javascript" src="../../node_modules/orbit-db-identity-provider/dist/index-browser.min.js" charset="utf-8"></script>
     <script type="text/javascript" src="../../node_modules/ipfs/dist/index.min.js" charset="utf-8"></script>
 
     <script type="text/javascript">
@@ -23,14 +24,14 @@
       ipfs.on('error', (e) => console.error(e))
 
       ipfs.on('ready', async () => {
-        const { AccessController, IdentityProvider } = Log
+        const { AccessController } = Log
         const keystore = Keystore.create(dataPath + '/keystore')
         const identitySignerFn = (id, data) => {
           const key = keystore.getKey(id)
           return keystore.sign(key, data)
         }
         const access = new AccessController()
-        const identity = await IdentityProvider.createIdentity(keystore, 'exampleUser', identitySignerFn)
+        const identity = await Identities.createIdentity({ id: 'exampleUser', keystore })
         const outputElm = document.getElementById('output')
 
         // When IPFS is ready, add some log entries

--- a/examples/browser/index.js
+++ b/examples/browser/index.js
@@ -2,8 +2,9 @@
 
 const IPFS = require('ipfs')
 const Keystore = require('orbit-db-keystore')
+const IdentityProvider = require('orbit-db-identity-provider')
 const Log = require('../../src/log')
-const { AccessController, IdentityProvider } = Log
+const { AccessController } = Log
 
 const dataPath = './ipfs-log/examples/browser/ipfs-0.30.0'
 const ipfs = new IPFS({
@@ -18,12 +19,8 @@ ipfs.on('error', (e) => console.error(e))
 
 ipfs.on('ready', async () => {
   const keystore = Keystore.create(dataPath + '/keystore')
-  const identitySignerFn = (id, data) => {
-    const key = keystore.getKey(id)
-    return keystore.sign(key, data)
-  }
   const access = new AccessController()
-  const identity = await IdentityProvider.createIdentity(keystore, 'exampleUser', identitySignerFn)
+  const identity = await IdentityProvider.createIdentity({ id: 'exampleUser', keystore })
   const outputElm = document.getElementById('output')
 
   // When IPFS is ready, add some log entries

--- a/package-lock.json
+++ b/package-lock.json
@@ -131,9 +131,9 @@
       }
     },
     "ajv": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.1.tgz",
-      "integrity": "sha512-ZoJjft5B+EJBjUyu9C9Hc0OZyPZSSlOF+plzouTrg6UlA8f+e/n8NIgBFG/9tppJtpPWfthHakK7juJdNDODww==",
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.2.tgz",
+      "integrity": "sha512-FBHEW6Jf5TB9MGBgUUA9XHkTbjXYfAUjY43ACMfmdMRHniyoMHjHjzD50OK8LGDWQwp4rWEsIq5kEqq7rvIM1g==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^2.0.1",
@@ -2921,9 +2921,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.91",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.91.tgz",
-      "integrity": "sha512-wOWwM4vQpmb97VNkExnwE5e/sUMUb7NXurlEnhE89JOarUp6FOOMKjtTGgj9bmqskZkeRA7u+p0IztJ/y2OP5Q==",
+      "version": "1.3.92",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.92.tgz",
+      "integrity": "sha512-En051LMzMl3/asMWGZEtU808HOoVWIpmmZx1Ep8N+TT9e7z/X8RcLeBU2kLSNLGQ+5SuKELzMx+MVuTBXk6Q9w==",
       "dev": true
     },
     "elliptic": {
@@ -6971,9 +6971,9 @@
           },
           "dependencies": {
             "readable-stream": {
-              "version": "3.0.6",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.0.6.tgz",
-              "integrity": "sha512-9E1oLoOWfhSXHGv6QlwXJim7uNzd9EVlWK+21tCU9Ju/kR0/p2AZYPz4qSchgO8PlLIH4FpZYfzwS+rEksZjIg==",
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.0.tgz",
+              "integrity": "sha512-vpydAvIJvPODZNagCPuHG87O9JNPtvFEtjHHRVwNVsVVRBqemvPJkc2SYbxJsiZXawJdtZNmkmnsPuE3IgsG0A==",
               "dev": true,
               "requires": {
                 "inherits": "^2.0.3",
@@ -8401,9 +8401,9 @@
       }
     },
     "libp2p-floodsub": {
-      "version": "0.15.3",
-      "resolved": "https://registry.npmjs.org/libp2p-floodsub/-/libp2p-floodsub-0.15.3.tgz",
-      "integrity": "sha512-pxtHddNE/qOIUiOGy98PSeDaFTYCgBZdOEtF9W6IsarfX5+F8Lkn1zUpwKdRQKPp3kafuRGlAVy5qVf0ZxpA3A==",
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/libp2p-floodsub/-/libp2p-floodsub-0.15.5.tgz",
+      "integrity": "sha512-c9aq+vHJLwipOjM37tZruPJqEw1Anw2PU3PGmYAF1DcqTERHoqeniALkbznR2cDMoxEDJqk4KRYrTFU4eam+rQ==",
       "dev": true,
       "requires": {
         "async": "^2.6.1",
@@ -8688,9 +8688,9 @@
           }
         },
         "readable-stream": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.0.6.tgz",
-          "integrity": "sha512-9E1oLoOWfhSXHGv6QlwXJim7uNzd9EVlWK+21tCU9Ju/kR0/p2AZYPz4qSchgO8PlLIH4FpZYfzwS+rEksZjIg==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.0.tgz",
+          "integrity": "sha512-vpydAvIJvPODZNagCPuHG87O9JNPtvFEtjHHRVwNVsVVRBqemvPJkc2SYbxJsiZXawJdtZNmkmnsPuE3IgsG0A==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -10111,9 +10111,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-      "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.0.tgz",
+      "integrity": "sha512-zT5nC0JhbljmyEf+Z456nvm7iO7XgRV2hYxoBtPpnyp+0Q4aCoP6uWNn76v/I6k2kCYNLWqWbwBWQcjsNI/bjw==",
       "dev": true
     },
     "nanoid": {
@@ -10563,7 +10563,7 @@
       "dev": true
     },
     "orbit-db-identity-provider": {
-      "version": "github:orbitdb/orbit-db-identity-provider#d7f7f1eff46d62c21ffbd1c6aa75ded90e3d37df",
+      "version": "github:orbitdb/orbit-db-identity-provider#fe9fc88334472ed080a89baa9ae375ced33e08dc",
       "from": "github:orbitdb/orbit-db-identity-provider"
     },
     "orbit-db-keystore": {
@@ -13421,7 +13421,7 @@
     },
     "string-width": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "requires": {
@@ -13690,7 +13690,7 @@
     },
     "temp": {
       "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
+      "resolved": "http://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
       "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
       "dev": true,
       "requires": {
@@ -15054,7 +15054,7 @@
               "dependencies": {
                 "string-width": {
                   "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                  "resolved": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
                   "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                   "dev": true,
                   "requires": {


### PR DESCRIPTION
This PR will fix browser examples. It changes the code to use the latest identity-providers that was recently merged.

Depends on having a [dist build for `orbit-db-identity-providers`](https://github.com/orbitdb/orbit-db-identity-provider/issues/15) used here: https://github.com/orbitdb/ipfs-log/compare/fix/browser-examples?expand=1#diff-e61c85e637a9c769088cb5eef3c51bd4R11.