### PR TITLE
Update README.md to include LTS node.js preference

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ It was originally created for, and currently used in, [orbit-db](https://github.
 ## Requirements
 
 - Node.js v8.6.0 or newer (uses `...` spread syntax)
+- Preferably you should use an LTS version of node.js (even numbered 8, 10, etc)
 
 ## Install
 


### PR DESCRIPTION
## Description (Required)

On investigating https://github.com/orbitdb/ipfs-log/issues/206, @satazor discovered that this was an issue with a js-ipfs dependency detailed here: https://github.com/dignifiedquire/lock-me/issues/4

While waiting for that to be fixed, the best we can do is propose that people use LTS versions of node.js when using our software. Thoughts?

## Other changes (e.g. bug fixes, UI tweaks, refactors)

Also opened up a PR in the main `orbit-db` repo https://github.com/orbitdb/orbit-db/pull/538

Resolves #206 
