### PR TITLE
Fix exclude array passed in fetchParallel

### DIFF
--- a/src/entry-io.js
+++ b/src/entry-io.js
@@ -39,7 +39,12 @@ class EntryIO {
 
     // Add entries that we don't need to fetch to the "cache"
     exclude = exclude && Array.isArray(exclude) ? exclude : []
-    var addToExcludeCache = e => (cache[e.hash] = e)
+    var addToExcludeCache = e => {
+      if (Entry.isEntry(e)) {
+        result.push(e)
+        cache[e.hash] = e
+      }
+    }
     exclude.forEach(addToExcludeCache)
 
     const shouldFetchMore = () => {

--- a/src/log-io.js
+++ b/src/log-io.js
@@ -112,11 +112,10 @@ class LogIO {
     length = length > -1 ? Math.max(length, sourceEntries.length) : length
 
     // Make sure we pass hashes instead of objects to the fetcher function
-    const excludeHashes = exclude ? exclude.map(e => e.hash ? e.hash : e) : exclude
     const hashes = sourceEntries.map(e => e.hash)
 
     // Fetch the entries
-    const entries = await EntryIO.fetchParallel(ipfs, hashes, length, excludeHashes, null, null, onProgressCallback)
+    const entries = await EntryIO.fetchParallel(ipfs, hashes, length, exclude, null, null, onProgressCallback)
 
     // Combine the fetches with the source entries and take only uniques
     const combined = sourceEntries.concat(entries)


### PR DESCRIPTION
This PR fixes the exclude array passed in fetchParallel call to be Entries instead of hash strings.