### PR TITLE
Adding SHELL variable to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL=/bin/bash
+
 all: build
 
 deps:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-SHELL=/bin/bash
-
 all: build
 
 deps:
@@ -22,7 +20,7 @@ clean:
 	rm -rf test/keystore/
 
 clean-dependencies: clean
-	if [ -a package-lock.json ]; then rm package-lock.json; fi;
+	rm -f package-lock.json
 
 rebuild: | clean-dependencies build
 	


### PR DESCRIPTION
## Description (Required)

When running `make rebuld` I noticed an error:

```bash
$ make rebuild
rm -rf ipfs/
rm -rf ipfs-log-benchmarks/
rm -rf node_modules/
rm -rf coverage/
rm -rf test/keystore/
if [ -a package-lock.json ]; then rm package-lock.json; fi;
/bin/sh: 1: [: -a: unexpected operator
```

This PR simply removes the conditional to just use `rm -f package-lock.json`