### PR TITLE
Patch/v4.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71,12 +71,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
-      "integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
+      "integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.4.0",
+        "@babel/types": "^7.4.4",
         "jsesc": "^2.5.1",
         "lodash": "^4.17.11",
         "source-map": "^0.5.0",
@@ -103,24 +103,24 @@
       }
     },
     "@babel/helper-call-delegate": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.4.0.tgz",
-      "integrity": "sha512-SdqDfbVdNQCBp3WhK2mNdDvHd3BD6qbmIc43CAyjnsfCmgHMeqgDcM3BzY2lchi7HBJGJ2CVdynLWbezaE4mmQ==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.4.4.tgz",
+      "integrity": "sha512-l79boDFJ8S1c5hvQvG+rc+wHw6IuH7YldmRKsYtpbawsxURu/paVy57FZMomGK22/JckepaikOkY0MoAmdyOlQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-hoist-variables": "^7.4.0",
-        "@babel/traverse": "^7.4.0",
-        "@babel/types": "^7.4.0"
+        "@babel/helper-hoist-variables": "^7.4.4",
+        "@babel/traverse": "^7.4.4",
+        "@babel/types": "^7.4.4"
       }
     },
     "@babel/helper-define-map": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.4.0.tgz",
-      "integrity": "sha512-wAhQ9HdnLIywERVcSvX40CEJwKdAa1ID4neI9NXQPDOHwwA+57DqwLiPEVy2AIyWzAk0CQ8qx4awO0VUURwLtA==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.4.4.tgz",
+      "integrity": "sha512-IX3Ln8gLhZpSuqHJSnTNBWGDE9kdkTEWl21A/K7PQ00tseBwbqCHTvNLHSBd9M0R5rER4h5Rsvj9vw0R5SieBg==",
       "dev": true,
       "requires": {
         "@babel/helper-function-name": "^7.1.0",
-        "@babel/types": "^7.4.0",
+        "@babel/types": "^7.4.4",
         "lodash": "^4.17.11"
       }
     },
@@ -155,12 +155,12 @@
       }
     },
     "@babel/helper-hoist-variables": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.0.tgz",
-      "integrity": "sha512-/NErCuoe/et17IlAQFKWM24qtyYYie7sFIrW/tIQXpck6vAu2hhtYYsKLBWQV+BQZMbcIYPU/QMYuTufrY4aQw==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.4.tgz",
+      "integrity": "sha512-VYk2/H/BnYbZDDg39hr3t2kKyifAm1W6zHRfhx8jGjIHpQEBv9dry7oQ2f3+J703TLu69nYdxsovl0XYfcnK4w==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.4.0"
+        "@babel/types": "^7.4.4"
       }
     },
     "@babel/helper-member-expression-to-functions": {
@@ -182,17 +182,17 @@
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.2.2.tgz",
-      "integrity": "sha512-YRD7I6Wsv+IHuTPkAmAS4HhY0dkPobgLftHp0cRGZSdrRvmZY8rFvae/GVu3bD00qscuvK3WPHB3YdNpBXUqrA==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.4.4.tgz",
+      "integrity": "sha512-3Z1yp8TVQf+B4ynN7WoHPKS8EkdTbgAEy0nU0rs/1Kw4pDgmvYH3rz3aI11KgxKCba2cn7N+tqzV1mY2HMN96w==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/helper-simple-access": "^7.1.0",
-        "@babel/helper-split-export-declaration": "^7.0.0",
-        "@babel/template": "^7.2.2",
-        "@babel/types": "^7.2.2",
-        "lodash": "^4.17.10"
+        "@babel/helper-split-export-declaration": "^7.4.4",
+        "@babel/template": "^7.4.4",
+        "@babel/types": "^7.4.4",
+        "lodash": "^4.17.11"
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -211,12 +211,12 @@
       "dev": true
     },
     "@babel/helper-regex": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0.tgz",
-      "integrity": "sha512-TR0/N0NDCcUIUEbqV6dCO+LptmmSQFQ7q70lfcEB4URsjD0E1HzicrwUH+ap6BAQ2jhCX9Q4UqZy4wilujWlkg==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.4.4.tgz",
+      "integrity": "sha512-Y5nuB/kESmR3tKjU8Nkn1wMGEx1tjJX076HBMeL3XLQCu6vA/YRzuTW0bbb+qRnXvQGn+d6Rx953yffl8vEy7Q==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.10"
+        "lodash": "^4.17.11"
       }
     },
     "@babel/helper-remap-async-to-generator": {
@@ -233,15 +233,15 @@
       }
     },
     "@babel/helper-replace-supers": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.4.0.tgz",
-      "integrity": "sha512-PVwCVnWWAgnal+kJ+ZSAphzyl58XrFeSKSAJRiqg5QToTsjL+Xu1f9+RJ+d+Q0aPhPfBGaYfkox66k86thxNSg==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.4.4.tgz",
+      "integrity": "sha512-04xGEnd+s01nY1l15EuMS1rfKktNF+1CkKmHoErDppjAAZL+IUBZpzT748x262HF7fibaQPhbvWUl5HeSt1EXg==",
       "dev": true,
       "requires": {
         "@babel/helper-member-expression-to-functions": "^7.0.0",
         "@babel/helper-optimise-call-expression": "^7.0.0",
-        "@babel/traverse": "^7.4.0",
-        "@babel/types": "^7.4.0"
+        "@babel/traverse": "^7.4.4",
+        "@babel/types": "^7.4.4"
       }
     },
     "@babel/helper-simple-access": {
@@ -255,12 +255,12 @@
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.0.tgz",
-      "integrity": "sha512-7Cuc6JZiYShaZnybDmfwhY4UYHzI6rlqhWjaIqbsJGsIqPimEYy5uh3akSRLMg65LSdSEnJ8a8/bWQN6u2oMGw==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+      "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.4.0"
+        "@babel/types": "^7.4.4"
       }
     },
     "@babel/helper-wrap-function": {
@@ -276,14 +276,14 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.2.tgz",
-      "integrity": "sha512-gQR1eQeroDzFBikhrCccm5Gs2xBjZ57DNjGbqTaHo911IpmSxflOQWMAHPw/TXk8L3isv7s9lYzUkexOeTQUYg==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.4.tgz",
+      "integrity": "sha512-igczbR/0SeuPR8RFfC7tGrbdTbFL3QTvH6D+Z6zNxnTe//GyqmtHmDkzrqDmyZ3eSwPqB/LhyKoU5DXsp+Vp2A==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.4.0",
-        "@babel/traverse": "^7.4.0",
-        "@babel/types": "^7.4.0"
+        "@babel/template": "^7.4.4",
+        "@babel/traverse": "^7.4.4",
+        "@babel/types": "^7.4.4"
       }
     },
     "@babel/highlight": {
@@ -298,9 +298,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.2.tgz",
-      "integrity": "sha512-9fJTDipQFvlfSVdD/JBtkiY0br9BtfvW2R8wo6CX/Ej2eMuV0gWPk1M67Mt3eggQvBqYW1FCEk8BN7WvGm/g5g==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.4.tgz",
+      "integrity": "sha512-5pCS4mOsL+ANsFZGdvNLybx4wtqAZJ0MJjMHxvzI3bvIsz6sQvzW8XX92EYIkiPtIvcfG3Aj+Ir5VNyjnZhP7w==",
       "dev": true
     },
     "@babel/plugin-proposal-async-generator-functions": {
@@ -325,9 +325,9 @@
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.0.tgz",
-      "integrity": "sha512-uTNi8pPYyUH2eWHyYWWSYJKwKg34hhgl4/dbejEjL+64OhbHjTX7wEVWMQl82tEmdDsGeu77+s8HHLS627h6OQ==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.4.tgz",
+      "integrity": "sha512-dMBG6cSPBbHeEBdFXeQ2QLc5gUpg4Vkaz8octD4aoW/ISO+jBOcsuxYL7bsb5WSu8RLP6boxrBIALEHgoHtO9g==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -345,13 +345,13 @@
       }
     },
     "@babel/plugin-proposal-unicode-property-regex": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.4.0.tgz",
-      "integrity": "sha512-h/KjEZ3nK9wv1P1FSNb9G079jXrNYR0Ko+7XkOx85+gM24iZbPn0rh4vCftk+5QKY7y1uByFataBTmX7irEF1w==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.4.4.tgz",
+      "integrity": "sha512-j1NwnOqMG9mFUOH58JTFsA/+ZYzQLUZ/drqWUqxCYLGeu2JFZL8YrNC9hBxKmWtAuOCHPcRpgv7fhap09Fb4kA==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-regex": "^7.0.0",
+        "@babel/helper-regex": "^7.4.4",
         "regexpu-core": "^4.5.4"
       }
     },
@@ -401,9 +401,9 @@
       }
     },
     "@babel/plugin-transform-async-to-generator": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.4.0.tgz",
-      "integrity": "sha512-EeaFdCeUULM+GPFEsf7pFcNSxM7hYjoj5fiYbyuiXobW4JhFnjAv9OWzNwHyHcKoPNpAfeRDuW6VyaXEDUBa7g==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.4.4.tgz",
+      "integrity": "sha512-YiqW2Li8TXmzgbXw+STsSqPBPFnGviiaSp6CYOq55X8GQ2SGVLrXB6pNid8HkqkZAzOH6knbai3snhP7v0fNwA==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
@@ -421,9 +421,9 @@
       }
     },
     "@babel/plugin-transform-block-scoping": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.4.0.tgz",
-      "integrity": "sha512-AWyt3k+fBXQqt2qb9r97tn3iBwFpiv9xdAiG+Gr2HpAZpuayvbL55yWrsV3MyHvXk/4vmSiedhDRl1YI2Iy5nQ==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.4.4.tgz",
+      "integrity": "sha512-jkTUyWZcTrwxu5DD4rWz6rDB5Cjdmgz6z7M7RLXOJyCUkFBawssDGcGh8M/0FTSB87avyJI1HsTwUXp9nKA1PA==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -431,18 +431,18 @@
       }
     },
     "@babel/plugin-transform-classes": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.4.0.tgz",
-      "integrity": "sha512-XGg1Mhbw4LDmrO9rSTNe+uI79tQPdGs0YASlxgweYRLZqo/EQktjaOV4tchL/UZbM0F+/94uOipmdNGoaGOEYg==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.4.4.tgz",
+      "integrity": "sha512-/e44eFLImEGIpL9qPxSRat13I5QNRgBLu2hOQJCF7VLy/otSM/sypV1+XaIw5+502RX/+6YaSAPmldk+nhHDPw==",
       "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.0.0",
-        "@babel/helper-define-map": "^7.4.0",
+        "@babel/helper-define-map": "^7.4.4",
         "@babel/helper-function-name": "^7.1.0",
         "@babel/helper-optimise-call-expression": "^7.0.0",
         "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-replace-supers": "^7.4.0",
-        "@babel/helper-split-export-declaration": "^7.4.0",
+        "@babel/helper-replace-supers": "^7.4.4",
+        "@babel/helper-split-export-declaration": "^7.4.4",
         "globals": "^11.1.0"
       }
     },
@@ -456,23 +456,23 @@
       }
     },
     "@babel/plugin-transform-destructuring": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.4.0.tgz",
-      "integrity": "sha512-HySkoatyYTY3ZwLI8GGvkRWCFrjAGXUHur5sMecmCIdIharnlcWWivOqDJI76vvmVZfzwb6G08NREsrY96RhGQ==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.4.4.tgz",
+      "integrity": "sha512-/aOx+nW0w8eHiEHm+BTERB2oJn5D127iye/SUQl7NjHy0lf+j7h4MKMMSOwdazGq9OxgiNADncE+SRJkCxjZpQ==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-dotall-regex": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.2.0.tgz",
-      "integrity": "sha512-sKxnyHfizweTgKZf7XsXu/CNupKhzijptfTM+bozonIuyVrLWVUvYjE2bhuSBML8VQeMxq4Mm63Q9qvcvUcciQ==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.4.4.tgz",
+      "integrity": "sha512-P05YEhRc2h53lZDjRPk/OektxCVevFzZs2Gfjd545Wde3k+yFDbXORgl2e0xpbq8mLcKJ7Idss4fAg0zORN/zg==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-regex": "^7.0.0",
-        "regexpu-core": "^4.1.3"
+        "@babel/helper-regex": "^7.4.4",
+        "regexpu-core": "^4.5.4"
       }
     },
     "@babel/plugin-transform-duplicate-keys": {
@@ -495,18 +495,18 @@
       }
     },
     "@babel/plugin-transform-for-of": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.0.tgz",
-      "integrity": "sha512-vWdfCEYLlYSxbsKj5lGtzA49K3KANtb8qCPQ1em07txJzsBwY+cKJzBHizj5fl3CCx7vt+WPdgDLTHmydkbQSQ==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.4.tgz",
+      "integrity": "sha512-9T/5Dlr14Z9TIEXLXkt8T1DU7F24cbhwhMNUziN3hB1AXoZcdzPcTiKGRn/6iOymDqtTKWnr/BtRKN9JwbKtdQ==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-function-name": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.2.0.tgz",
-      "integrity": "sha512-kWgksow9lHdvBC2Z4mxTsvc7YdY7w/V6B2vy9cTIPtLEE9NhwoWivaxdNM/S37elu5bqlLP/qOY906LukO9lkQ==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.4.tgz",
+      "integrity": "sha512-iU9pv7U+2jC9ANQkKeNF6DrPy4GBa4NWQtl6dHB4Pb3izX2JOEvDTFarlNsBj/63ZEzNNIAMs3Qw4fNCcSOXJA==",
       "dev": true,
       "requires": {
         "@babel/helper-function-name": "^7.1.0",
@@ -544,12 +544,12 @@
       }
     },
     "@babel/plugin-transform-modules-systemjs": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.4.0.tgz",
-      "integrity": "sha512-gjPdHmqiNhVoBqus5qK60mWPp1CmYWp/tkh11mvb0rrys01HycEGD7NvvSoKXlWEfSM9TcL36CpsK8ElsADptQ==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.4.4.tgz",
+      "integrity": "sha512-MSiModfILQc3/oqnG7NrP1jHaSPryO6tA2kOMmAQApz5dayPxWiHqmq4sWH2xF5LcQK56LlbKByCd8Aah/OIkQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-hoist-variables": "^7.4.0",
+        "@babel/helper-hoist-variables": "^7.4.4",
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
@@ -564,9 +564,9 @@
       }
     },
     "@babel/plugin-transform-new-target": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.4.0.tgz",
-      "integrity": "sha512-6ZKNgMQmQmrEX/ncuCwnnw1yVGoaOW5KpxNhoWI7pCQdA0uZ0HqHGqenCUIENAnxRjy2WwNQ30gfGdIgqJXXqw==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.4.4.tgz",
+      "integrity": "sha512-r1z3T2DNGQwwe2vPGZMBNjioT2scgWzK9BCnDEh+46z8EEwXBq24uRzd65I7pjtugzPSj921aM15RpESgzsSuA==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -583,20 +583,20 @@
       }
     },
     "@babel/plugin-transform-parameters": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.0.tgz",
-      "integrity": "sha512-Xqv6d1X+doyiuCGDoVJFtlZx0onAX0tnc3dY8w71pv/O0dODAbusVv2Ale3cGOwfiyi895ivOBhYa9DhAM8dUA==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.4.tgz",
+      "integrity": "sha512-oMh5DUO1V63nZcu/ZVLQFqiihBGo4OpxJxR1otF50GMeCLiRx5nUdtokd+u9SuVJrvvuIh9OosRFPP4pIPnwmw==",
       "dev": true,
       "requires": {
-        "@babel/helper-call-delegate": "^7.4.0",
+        "@babel/helper-call-delegate": "^7.4.4",
         "@babel/helper-get-function-arity": "^7.0.0",
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-regenerator": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.0.tgz",
-      "integrity": "sha512-SZ+CgL4F0wm4npojPU6swo/cK4FcbLgxLd4cWpHaNXY/NJ2dpahODCqBbAwb2rDmVszVb3SSjnk9/vik3AYdBw==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.4.tgz",
+      "integrity": "sha512-Zz3w+pX1SI0KMIiqshFZkwnVGUhDZzpX2vtPzfJBKQQq8WsP/Xy9DNdELWivxcKOCX/Pywge4SiEaPaLtoDT4g==",
       "dev": true,
       "requires": {
         "regenerator-transform": "^0.13.4"
@@ -643,9 +643,9 @@
       }
     },
     "@babel/plugin-transform-template-literals": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.2.0.tgz",
-      "integrity": "sha512-FkPix00J9A/XWXv4VoKJBMeSkyY9x/TqIh76wzcdfl57RJJcf8CehQ08uwfhCDNtRQYtHQKBTwKZDEyjE13Lwg==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.4.4.tgz",
+      "integrity": "sha512-mQrEC4TWkhLN0z8ygIvEL9ZEToPhG5K7KDW3pzGqOfIGZ28Jb0POUkeWcoz8HnHvhFy6dwAT1j8OzqN8s804+g==",
       "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.0.0",
@@ -662,14 +662,14 @@
       }
     },
     "@babel/plugin-transform-unicode-regex": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.2.0.tgz",
-      "integrity": "sha512-m48Y0lMhrbXEJnVUaYly29jRXbQ3ksxPrS1Tg8t+MHqzXhtBYAvI51euOBaoAlZLPHsieY9XPVMf80a5x0cPcA==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.4.tgz",
+      "integrity": "sha512-il+/XdNw01i93+M9J9u4T7/e/Ue/vWfNZE4IRUQjplu2Mqb/AFTDimkw2tdEdSH50wuQXZAbXSql0UphQke+vA==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-regex": "^7.0.0",
-        "regexpu-core": "^4.1.3"
+        "@babel/helper-regex": "^7.4.4",
+        "regexpu-core": "^4.5.4"
       }
     },
     "@babel/preset-env": {
@@ -731,28 +731,28 @@
       }
     },
     "@babel/template": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.0.tgz",
-      "integrity": "sha512-SOWwxxClTTh5NdbbYZ0BmaBVzxzTh2tO/TeLTbF6MO6EzVhHTnff8CdBXx3mEtazFBoysmEM6GU/wF+SuSx4Fw==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
+      "integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.4.0",
-        "@babel/types": "^7.4.0"
+        "@babel/parser": "^7.4.4",
+        "@babel/types": "^7.4.4"
       }
     },
     "@babel/traverse": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.0.tgz",
-      "integrity": "sha512-/DtIHKfyg2bBKnIN+BItaIlEg5pjAnzHOIQe5w+rHAw/rg9g0V7T4rqPX8BJPfW11kt3koyjAnTNwCzb28Y1PA==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.4.tgz",
+      "integrity": "sha512-Gw6qqkw/e6AGzlyj9KnkabJX7VcubqPtkUQVAwkc0wUMldr3A/hezNB3Rc5eIvId95iSGkGIOe5hh1kMKf951A==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.4.0",
+        "@babel/generator": "^7.4.4",
         "@babel/helper-function-name": "^7.1.0",
-        "@babel/helper-split-export-declaration": "^7.4.0",
-        "@babel/parser": "^7.4.0",
-        "@babel/types": "^7.4.0",
+        "@babel/helper-split-export-declaration": "^7.4.4",
+        "@babel/parser": "^7.4.4",
+        "@babel/types": "^7.4.4",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.11"
@@ -776,9 +776,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
-      "integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+      "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2",
@@ -838,9 +838,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.14.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.5.tgz",
-      "integrity": "sha512-Ja7d4s0qyGFxjGeDq5S7Si25OFibSAHUi6i17UWnwNnpitADN7hah9q0Tl25gxuV5R1u2Bx+np6w4LHXfHyj/g=="
+      "version": "10.14.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.6.tgz",
+      "integrity": "sha512-Fvm24+u85lGmV4hT5G++aht2C5I4Z4dYlWZIh62FAfFO/TfzXtPpoLI6I7AuBWkIFqZCnhFOoTT7RjjaIL5Fjg=="
     },
     "@webassemblyjs/ast": {
       "version": "1.7.11",
@@ -1032,6 +1032,15 @@
       "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
       "dev": true
     },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
+    },
     "abstract-leveldown": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-5.0.0.tgz",
@@ -1068,13 +1077,13 @@
       }
     },
     "accepts": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
-      "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+      "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
       "dev": true,
       "requires": {
-        "mime-types": "~2.1.18",
-        "negotiator": "0.6.1"
+        "mime-types": "~2.1.24",
+        "negotiator": "0.6.2"
       }
     },
     "acorn": {
@@ -1403,18 +1412,18 @@
       }
     },
     "async-each": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.2.tgz",
-      "integrity": "sha512-6xrbvN0MOBKSJDdonmSSz2OwFSgxRaVtBDes26mj9KIGtDo+g9xosFRSC+i1gQh2oAN/tQ62AI/pGZGQjVOiRg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
+      "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
       "dev": true
     },
     "async-iterator-to-pull-stream": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/async-iterator-to-pull-stream/-/async-iterator-to-pull-stream-1.2.1.tgz",
-      "integrity": "sha512-STQB0sczzBjC1ttIQop4XdZLeFrGM6L4eq7LOit+CG+iwwIfGjIKzuAzZFzLqulZHp+Qu5fLk8V7kwLLYnNUlA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/async-iterator-to-pull-stream/-/async-iterator-to-pull-stream-1.3.0.tgz",
+      "integrity": "sha512-NjyhAEz/sx32olqgKIk/2xbWEM6o8qef1yetIgb0U/R3oBgndP1kE/0CslowH3jvnA94BO4I6OXpOkTKH7Z1AA==",
       "dev": true,
       "requires": {
-        "get-iterator": "^1.0.1",
+        "get-iterator": "^1.0.2",
         "pull-stream-to-async-iterator": "^1.0.1"
       }
     },
@@ -1664,9 +1673,9 @@
       "dev": true
     },
     "bip32": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bip32/-/bip32-1.0.2.tgz",
-      "integrity": "sha512-kedLYj8yvYzND+EfzeoMSlGiN7ImiRBF/MClJSZPkMfcU+OQO7ZpL5L/Yg+TunebBZIHhunstiQF//KLKSF5rg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/bip32/-/bip32-1.0.4.tgz",
+      "integrity": "sha512-8T21eLWylZETolyqCPgia+MNp+kY37zFr7PTFDTPObHeNi9JlfG4qGIh8WzerIJidtwoK+NsWq2I5i66YfHoIw==",
       "dev": true,
       "requires": {
         "bs58check": "^2.1.1",
@@ -1692,13 +1701,13 @@
       "dev": true
     },
     "bitcoinjs-lib": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-4.0.3.tgz",
-      "integrity": "sha512-cb5t55MYUpwQi095J+u6eyltgIU7lbhZfC6+annstncDhfH4cyctW5jmU/tac7NonZZFYH7DktWnDxUm9AWWDQ==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-4.0.5.tgz",
+      "integrity": "sha512-gYs7K2hiY4Xb96J8AIF+Rx+hqbwjVlp5Zt6L6AnHOdzfe/2tODdmDxsEytnaxVCdhOUg0JnsGpl+KowBpGLxtA==",
       "dev": true,
       "requires": {
         "bech32": "^1.1.2",
-        "bip32": "^1.0.0",
+        "bip32": "^1.0.4",
         "bip66": "^1.1.0",
         "bitcoin-ops": "^1.4.0",
         "bs58check": "^2.0.0",
@@ -1735,9 +1744,9 @@
       "dev": true
     },
     "bluebird": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
-      "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==",
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz",
+      "integrity": "sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw==",
       "dev": true
     },
     "bn.js": {
@@ -1948,14 +1957,14 @@
       }
     },
     "browserslist": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.2.tgz",
-      "integrity": "sha512-zmJVLiKLrzko0iszd/V4SsjTaomFeoVzQGYYOYgRgsbh7WNh95RgDB0CmBdFWYs/3MyFSt69NypjL/h3iaddKQ==",
+      "version": "4.5.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.6.tgz",
+      "integrity": "sha512-o/hPOtbU9oX507lIqon+UvPYqpx3mHc8cV3QemSBTXwkG8gSQSK6UKvXcE/DcleU3+A59XTUHyCvZ5qGy8xVAg==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30000951",
-        "electron-to-chromium": "^1.3.116",
-        "node-releases": "^1.1.11"
+        "caniuse-lite": "^1.0.30000963",
+        "electron-to-chromium": "^1.3.127",
+        "node-releases": "^1.1.17"
       }
     },
     "bs58": {
@@ -2138,15 +2147,15 @@
       "dev": true
     },
     "camelcase": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.2.0.tgz",
-      "integrity": "sha512-IXFsBS2pC+X0j0N/GE7Dm7j3bsEBp+oTpb7F50dwEVX7rf3IgwO9XatnegTsDtniKCUtEJH4fSU6Asw7uoVLfQ==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30000955",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000955.tgz",
-      "integrity": "sha512-6AwmIKgqCYfDWWadRkAuZSHMQP4Mmy96xAXEdRBlN/luQhlRYOKgwOlZ9plpCOsVbBuqbTmGqDK3JUM/nlr8CA==",
+      "version": "1.0.30000963",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000963.tgz",
+      "integrity": "sha512-n4HUiullc7Lw0LyzpeLa2ffP8KxFBGdxqD/8G3bSL6oB758hZ2UE2CVK+tQN958tJIi0/tfpjAc67aAtoHgnrQ==",
       "dev": true
     },
     "capture-stack-trace": {
@@ -2462,9 +2471,9 @@
       }
     },
     "commander": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
-      "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
       "dev": true
     },
     "commondir": {
@@ -2480,9 +2489,9 @@
       "dev": true
     },
     "component-emitter": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
       "dev": true
     },
     "component-inherit": {
@@ -2510,9 +2519,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.2.0.tgz",
-          "integrity": "sha512-RV20kLjdmpZuTF1INEb9IA3L68Nmi+Ri7ppZqo78wj//Pn62fCoJyV9zalccNzDD/OuJpMG4f+pfMl8+L6QdGw==",
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
+          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -2972,18 +2981,18 @@
       "dev": true
     },
     "deferred-leveldown": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-5.0.0.tgz",
-      "integrity": "sha512-QtTcNm2PX7elim5bGl+i3px2kVbpI49BV+Q62CFh0AaMlrdlbMXyozBg31p2zJqAAT35FUw4eccC+drr3D0+vQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-5.0.1.tgz",
+      "integrity": "sha512-BXohsvTedWOLkj2n/TY+yqVlrCWa2Zs8LSxh3uCAgFOru7/pjxKyZAexGa1j83BaKloER4PqUyQ9rGPJLt9bqA==",
       "requires": {
         "abstract-leveldown": "~6.0.0",
         "inherits": "^2.0.3"
       },
       "dependencies": {
         "abstract-leveldown": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.0.1.tgz",
-          "integrity": "sha512-8ccQIKHwmh7rIRWvKGgSTM2LByLWpLZgAYRjDNOh1ZTXvlR0gtm2Ir7aD8rEUre8DMllchJJTAZhhN5aUBN7XA==",
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.0.3.tgz",
+          "integrity": "sha512-jzewKKpZbaYUa6HTThnrl+GrJhzjEAeuc7hTVpZdzg7kupXZFoqQDFwyOwLNbmJKJlmzw8yiipMPkDiuKkT06Q==",
           "requires": {
             "level-concat-iterator": "~2.0.0",
             "xtend": "~4.0.0"
@@ -3229,9 +3238,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.120",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.120.tgz",
-      "integrity": "sha512-p1pgKOSSgcROCRiZoJ5H5wFmhqdA0L3yLL9mlfcmdA4V60IDCrsvhNqN8rLPe9e3B772Gm02kBkL1GM/g2lENg==",
+      "version": "1.3.128",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.128.tgz",
+      "integrity": "sha512-1QK+KELj1mhC9iE7grSP9PP2f06F85UgTs0M9qjuvSuKwxbyifhyPB8dZ27IlYvzMBnLtO4oHNBKTQoN6Tg5mg==",
       "dev": true
     },
     "elliptic": {
@@ -3325,6 +3334,12 @@
         "yeast": "0.1.2"
       },
       "dependencies": {
+        "component-emitter": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+          "dev": true
+        },
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -3584,9 +3599,9 @@
       }
     },
     "eslint-module-utils": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.3.0.tgz",
-      "integrity": "sha512-lmDJgeOOjk8hObTysjqH7wyMi+nsHwwvfBykwfhjR1LNdd7C2uFJBvx4OpWYpXOw4df1yE1cDEVd1yLHitk34w==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.4.0.tgz",
+      "integrity": "sha512-14tltLm38Eu3zS+mt0KvILC3q8jyIAH518MlG+HO0p+yK885Lb1UHTY/UgR91eOyGdmxAPb+OLoW4znqIT6Ndw==",
       "dev": true,
       "requires": {
         "debug": "^2.6.8",
@@ -4132,6 +4147,12 @@
         "strip-hex-prefix": "1.0.0"
       }
     },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true
+    },
     "events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
@@ -4395,9 +4416,9 @@
       }
     },
     "file-type": {
-      "version": "10.9.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-10.9.0.tgz",
-      "integrity": "sha512-9C5qtGR/fNibHC5gzuMmmgnjH3QDDLKMa8lYe9CiZVmAnI4aUaoMh40QyUPzzs0RYo837SOBKh7TYwle4G8E4w==",
+      "version": "10.11.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-10.11.0.tgz",
+      "integrity": "sha512-uzk64HRpUZyTGZtVuvrjP0FYxzQrBf4rojot6J65YMEbwBLB0CWm0CLojVpwpmFmxcE/lkvYICgfcGozbBq6rw==",
       "dev": true
     },
     "filereader-stream": {
@@ -4582,14 +4603,14 @@
       "dev": true
     },
     "fsevents": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.7.tgz",
-      "integrity": "sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
+      "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "^2.9.2",
-        "node-pre-gyp": "^0.10.0"
+        "nan": "^2.12.1",
+        "node-pre-gyp": "^0.12.0"
       },
       "dependencies": {
         "abbrev": {
@@ -4667,12 +4688,12 @@
           "optional": true
         },
         "debug": {
-          "version": "2.6.9",
+          "version": "4.1.1",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
           }
         },
         "deep-extend": {
@@ -4843,24 +4864,31 @@
           }
         },
         "ms": {
-          "version": "2.0.0",
+          "version": "2.1.1",
           "bundled": true,
           "dev": true,
           "optional": true
         },
+        "nan": {
+          "version": "2.13.2",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
+          "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
+          "dev": true,
+          "optional": true
+        },
         "needle": {
-          "version": "2.2.4",
+          "version": "2.3.0",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "^2.1.2",
+            "debug": "^4.1.0",
             "iconv-lite": "^0.4.4",
             "sax": "^1.2.4"
           }
         },
         "node-pre-gyp": {
-          "version": "0.10.3",
+          "version": "0.12.0",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -4888,13 +4916,13 @@
           }
         },
         "npm-bundled": {
-          "version": "1.0.5",
+          "version": "1.0.6",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
-          "version": "1.2.0",
+          "version": "1.4.1",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -5033,7 +5061,7 @@
           "optional": true
         },
         "semver": {
-          "version": "5.6.0",
+          "version": "5.7.0",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -5847,15 +5875,15 @@
       "dev": true
     },
     "globals": {
-      "version": "11.11.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
-      "integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==",
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
     },
     "go-ipfs-dep": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/go-ipfs-dep/-/go-ipfs-dep-0.4.19.tgz",
-      "integrity": "sha512-3mIdQPJXe2aImWWLa9vhqwSViOkobS0uXRgBDiZ8TfJumfx7kq24EoHNfqqAX9RjU4VPV7JkASJXoTUCW7GAig==",
+      "version": "0.4.20",
+      "resolved": "https://registry.npmjs.org/go-ipfs-dep/-/go-ipfs-dep-0.4.20.tgz",
+      "integrity": "sha512-Ds+ZIoh3rM1nfxoJ8PM1mhuOy/fzNIwWtWUP7kC7QeWv3GywvPzagbMT/9eSmGi4+Eu66mopxlhYn5AiZI/iVA==",
       "dev": true,
       "requires": {
         "go-platform": "^1.0.0",
@@ -5885,9 +5913,9 @@
           }
         },
         "readable-stream": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.2.0.tgz",
-          "integrity": "sha512-RV20kLjdmpZuTF1INEb9IA3L68Nmi+Ri7ppZqo78wj//Pn62fCoJyV9zalccNzDD/OuJpMG4f+pfMl8+L6QdGw==",
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
+          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -5991,9 +6019,9 @@
       }
     },
     "handlebars": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.1.tgz",
-      "integrity": "sha512-3Zhi6C0euYZL5sM0Zcy7lInLXKQ+YLcF/olbN010mzGQ4XVm50JeyBnMqofHh696GrciGruC7kCcApPDJvVgwA==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
+      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -6053,16 +6081,6 @@
         "topo": "2.x.x"
       },
       "dependencies": {
-        "ammo": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/ammo/-/ammo-2.0.4.tgz",
-          "integrity": "sha1-v4CqshFpjqePY+9efxE91dnokX8=",
-          "dev": true,
-          "requires": {
-            "boom": "5.x.x",
-            "hoek": "4.x.x"
-          }
-        },
         "boom": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
@@ -6096,20 +6114,6 @@
             "hoek": "4.x.x",
             "isemail": "3.x.x",
             "topo": "2.x.x"
-          }
-        },
-        "teamwork": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/teamwork/-/teamwork-3.0.3.tgz",
-          "integrity": "sha512-OCB56z+G70iA1A1OFoT+51TPzfcgN0ks75uN3yhxA+EU66WTz2BevNDK4YzMqfaL5tuAvxy4iFUn35/u8pxMaQ=="
-        },
-        "topo": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
-          "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
-          "dev": true,
-          "requires": {
-            "hoek": "4.x.x"
           }
         }
       }
@@ -6814,9 +6818,9 @@
           }
         },
         "readable-stream": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.2.0.tgz",
-          "integrity": "sha512-RV20kLjdmpZuTF1INEb9IA3L68Nmi+Ri7ppZqo78wj//Pn62fCoJyV9zalccNzDD/OuJpMG4f+pfMl8+L6QdGw==",
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
+          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -7007,9 +7011,9 @@
           }
         },
         "readable-stream": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.2.0.tgz",
-          "integrity": "sha512-RV20kLjdmpZuTF1INEb9IA3L68Nmi+Ri7ppZqo78wj//Pn62fCoJyV9zalccNzDD/OuJpMG4f+pfMl8+L6QdGw==",
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
+          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -7250,9 +7254,9 @@
           }
         },
         "readable-stream": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.2.0.tgz",
-          "integrity": "sha512-RV20kLjdmpZuTF1INEb9IA3L68Nmi+Ri7ppZqo78wj//Pn62fCoJyV9zalccNzDD/OuJpMG4f+pfMl8+L6QdGw==",
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
+          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -7263,9 +7267,9 @@
       }
     },
     "ipfsd-ctl": {
-      "version": "0.42.1",
-      "resolved": "https://registry.npmjs.org/ipfsd-ctl/-/ipfsd-ctl-0.42.1.tgz",
-      "integrity": "sha512-wuaGL0oPgABi4UGf3fIFuTIqZg04E+X9Ny7VXlZ+xWB4nL64u+cSx3wl/SW/AkZvq5ExAL2fIFZRyCMQtrYGzA==",
+      "version": "0.42.2",
+      "resolved": "https://registry.npmjs.org/ipfsd-ctl/-/ipfsd-ctl-0.42.2.tgz",
+      "integrity": "sha512-+Vu8GBJ8sX12x96gxCuYKHdYeAiT4o+EFLmNERGla4ZKskpMa2NkNAYex/Yf23Q/ZU/7ZBW79PUPM0AL+DlVGg==",
       "dev": true,
       "requires": {
         "async": "^2.6.2",
@@ -7313,6 +7317,7 @@
         "concat-stream": {
           "version": "github:hugomrdias/concat-stream#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
           "from": "github:hugomrdias/concat-stream#feat/smaller",
+          "dev": true,
           "requires": {
             "inherits": "^2.0.3",
             "readable-stream": "^3.0.2"
@@ -7328,15 +7333,16 @@
           }
         },
         "ipfs-http-client": {
-          "version": "30.1.1",
-          "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-30.1.1.tgz",
-          "integrity": "sha512-tMqSwEhW57VnjHDBLjKKlgtAvlhkqVSR3oIFC0IiGnaM1nzcw7pbFBoHaFzl0PKIuXm40a5bJt85Rm2trYx+Ag==",
+          "version": "30.1.4",
+          "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-30.1.4.tgz",
+          "integrity": "sha512-ordvoPT3lAFL5qsvdYBeDGRP03gtbL6Jl+qJ9dztyhE7NJf2yhtnU3ZNqN1JMCcUK0qpGsDzX89t8dKQvI80Pw==",
           "dev": true,
           "requires": {
             "async": "^2.6.1",
             "bignumber.js": "^8.0.2",
             "bl": "^3.0.0",
             "bs58": "^4.0.1",
+            "buffer": "^5.2.1",
             "cids": "~0.5.5",
             "concat-stream": "github:hugomrdias/concat-stream#feat/smaller",
             "debug": "^4.1.0",
@@ -7351,7 +7357,7 @@
             "is-ipfs": "~0.6.0",
             "is-pull-stream": "0.0.0",
             "is-stream": "^1.1.0",
-            "iso-stream-http": "~0.1.1",
+            "iso-stream-http": "~0.1.2",
             "iso-url": "~0.4.6",
             "just-kebab-case": "^1.1.0",
             "just-map-keys": "^1.1.0",
@@ -7367,46 +7373,13 @@
             "promisify-es6": "^1.0.3",
             "pull-defer": "~0.2.3",
             "pull-stream": "^3.6.9",
-            "pull-to-stream": "~0.1.0",
+            "pull-to-stream": "~0.1.1",
             "pump": "^3.0.0",
             "qs": "^6.5.2",
             "readable-stream": "^3.1.1",
             "stream-to-pull-stream": "^1.7.2",
             "tar-stream": "^2.0.1",
             "through2": "^3.0.1"
-          },
-          "dependencies": {
-            "concat-stream": {
-              "version": "github:hugomrdias/concat-stream#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
-              "from": "github:hugomrdias/concat-stream#feat/smaller",
-              "dev": true,
-              "requires": {
-                "inherits": "^2.0.3",
-                "readable-stream": "^3.0.2"
-              }
-            },
-            "ndjson": {
-              "version": "github:hugomrdias/ndjson#4db16da6b42e5b39bf300c3a7cde62abb3fa3a11",
-              "from": "github:hugomrdias/ndjson#feat/readable-stream3",
-              "dev": true,
-              "requires": {
-                "json-stringify-safe": "^5.0.1",
-                "minimist": "^1.2.0",
-                "split2": "^3.1.0",
-                "through2": "^3.0.0"
-              },
-              "dependencies": {
-                "split2": {
-                  "version": "3.1.1",
-                  "resolved": "https://registry.npmjs.org/split2/-/split2-3.1.1.tgz",
-                  "integrity": "sha512-emNzr1s7ruq4N+1993yht631/JH+jaj0NYBosuKmLcq+JkGQ9MmTw1RB1fGaTCzUuseRIClrlSLHRNYGwWQ58Q==",
-                  "dev": true,
-                  "requires": {
-                    "readable-stream": "^3.0.0"
-                  }
-                }
-              }
-            }
           }
         },
         "ms": {
@@ -7418,9 +7391,11 @@
         "ndjson": {
           "version": "github:hugomrdias/ndjson#4db16da6b42e5b39bf300c3a7cde62abb3fa3a11",
           "from": "github:hugomrdias/ndjson#feat/readable-stream3",
+          "dev": true,
           "requires": {
             "json-stringify-safe": "^5.0.1",
             "minimist": "^1.2.0",
+            "split2": "^3.1.0",
             "through2": "^3.0.0"
           }
         },
@@ -7435,13 +7410,23 @@
           }
         },
         "readable-stream": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.2.0.tgz",
-          "integrity": "sha512-RV20kLjdmpZuTF1INEb9IA3L68Nmi+Ri7ppZqo78wj//Pn62fCoJyV9zalccNzDD/OuJpMG4f+pfMl8+L6QdGw==",
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
+          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
+          "dev": true,
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
             "util-deprecate": "^1.0.1"
+          }
+        },
+        "split2": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/split2/-/split2-3.1.1.tgz",
+          "integrity": "sha512-emNzr1s7ruq4N+1993yht631/JH+jaj0NYBosuKmLcq+JkGQ9MmTw1RB1fGaTCzUuseRIClrlSLHRNYGwWQ58Q==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "^3.0.0"
           }
         },
         "tar-stream": {
@@ -7461,6 +7446,7 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
           "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+          "dev": true,
           "requires": {
             "readable-stream": "2 || 3"
           }
@@ -7615,9 +7601,9 @@
       }
     },
     "ipns": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/ipns/-/ipns-0.5.0.tgz",
-      "integrity": "sha512-Uf/VWftFnCI0UtjL8VyGRgq62k5PrRzJrA0G43WoIuw7FNk6ggrt+3KAzhlukbYtlHYhOLWwF5eLDllqvurE6g==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/ipns/-/ipns-0.5.1.tgz",
+      "integrity": "sha512-m3e98GCcW3/XL0cTcigjjPgIn0uo1GVHOMIPcGgl0/nn/VQB43A8Vb74jbPZLEz4AxQfJz0AvO9gwOrke/fhig==",
       "dev": true,
       "requires": {
         "base32-encode": "^1.1.0",
@@ -8021,9 +8007,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.2.0.tgz",
-          "integrity": "sha512-RV20kLjdmpZuTF1INEb9IA3L68Nmi+Ri7ppZqo78wj//Pn62fCoJyV9zalccNzDD/OuJpMG4f+pfMl8+L6QdGw==",
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
+          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -8186,9 +8172,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
-      "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -8242,7 +8228,8 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
     },
     "json-text-sequence": {
       "version": "0.1.1",
@@ -8272,9 +8259,9 @@
       }
     },
     "jsx-ast-utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
-      "integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.1.0.tgz",
+      "integrity": "sha512-yDGDG2DS4JcqhA6blsuYbtsT09xL8AoLuUR2Gb5exrw7UEM19sBcOTq+YBBhrNbl0PUC4R4LnFu+dHg2HKeVvA==",
       "dev": true,
       "requires": {
         "array-includes": "^3.0.3"
@@ -8388,28 +8375,28 @@
       }
     },
     "level-codec": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.0.tgz",
-      "integrity": "sha512-OIpVvjCcZNP5SdhcNupnsI1zo5Y9Vpm+k/F1gfG5kXrtctlrwanisakweJtE0uA0OpLukRfOQae+Fg0M5Debhg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.1.tgz",
+      "integrity": "sha512-ajFP0kJ+nyq4i6kptSM+mAvJKLOg1X5FiFPtLG9M5gCEZyBmgDi3FkDrvlMkEzrUn1cWxtvVmrvoS4ASyO/q+Q==",
       "dev": true
     },
     "level-concat-iterator": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/level-concat-iterator/-/level-concat-iterator-2.0.0.tgz",
-      "integrity": "sha512-gMs7JtWp479SOBjJQteQ+WMctfiQXG1SX5EuIGWTTUP37mKqs6BcYcjfZVVzAdTq0lAcSYpL2xGwmCG/hbjOcg=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/level-concat-iterator/-/level-concat-iterator-2.0.1.tgz",
+      "integrity": "sha512-OTKKOqeav2QWcERMJR7IS9CUo1sHnke2C0gkSmcR7QuEtFNLLzHQAvnMw8ykvEcv0Qtkg0p7FOwP1v9e5Smdcw=="
     },
     "level-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.0.tgz",
-      "integrity": "sha512-AmY4HCp9h3OiU19uG+3YWkdELgy05OTP/r23aNHaQKWv8DO787yZgsEuGVkoph40uwN+YdUKnANlrxSsoOaaxg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.1.tgz",
+      "integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
       "requires": {
         "errno": "~0.1.1"
       }
     },
     "level-iterator-stream": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-4.0.0.tgz",
-      "integrity": "sha512-CHMqFgIGXmqbdfvZcNADxRBXrl2W2EN8stxZnxEDQfEN+oNULcbX1OSK7VqJutp51Z0yJtA4Ym3JJMOuEslTrA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-4.0.1.tgz",
+      "integrity": "sha512-pSZWqXK6/yHQkZKCHrR59nKpU5iqorKM22C/BOHTb/cwNQ2EOZG+bovmFFGcOgaBoF3KxqJEI27YwewhJQTzsw==",
       "requires": {
         "inherits": "^2.0.1",
         "readable-stream": "^3.0.2",
@@ -8417,9 +8404,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.2.0.tgz",
-          "integrity": "sha512-RV20kLjdmpZuTF1INEb9IA3L68Nmi+Ri7ppZqo78wj//Pn62fCoJyV9zalccNzDD/OuJpMG4f+pfMl8+L6QdGw==",
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
+          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -8585,9 +8572,9 @@
       }
     },
     "levelup": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/levelup/-/levelup-4.0.0.tgz",
-      "integrity": "sha512-RcWkjtMj1DGs8ftNs4U7MEZeHFnC9QcHn/fmBlOypHXCx02zwukZROzyUwRiu9dgw9y1tCDLFMmXQHEhCChi4w==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/levelup/-/levelup-4.0.1.tgz",
+      "integrity": "sha512-l7KXOkINXHgNqmz0v9bxvRnMCUG4gmShFrzFSZXXhcqFnfvKAW8NerVsTICpZtVhGOMAmhY6JsVoVh/tUPBmdg==",
       "requires": {
         "deferred-leveldown": "~5.0.0",
         "level-errors": "~2.0.0",
@@ -8835,22 +8822,23 @@
       }
     },
     "libp2p-kad-dht": {
-      "version": "0.14.10",
-      "resolved": "https://registry.npmjs.org/libp2p-kad-dht/-/libp2p-kad-dht-0.14.10.tgz",
-      "integrity": "sha512-nCUJa+0r5P4QE1pPc4CcklcuHJpibNzKVThSZkWI7wv3Bqte4Fqt6RbGPeW/7WmcoXNpBV1SK6uSgDS2Mp3EhA==",
+      "version": "0.14.13",
+      "resolved": "https://registry.npmjs.org/libp2p-kad-dht/-/libp2p-kad-dht-0.14.13.tgz",
+      "integrity": "sha512-mbR9m31m9/Ru1baraguDVEhGEt+OFy8kHGZVaULbTzLJNB53C05IW6NzzgC/v5d05fFFwnqDA9b1FYhGjr2gow==",
       "dev": true,
       "requires": {
+        "abort-controller": "^3.0.0",
         "async": "^2.6.2",
         "base32.js": "~0.1.0",
         "chai-checkmark": "^1.0.1",
-        "cids": "~0.5.7",
+        "cids": "~0.6.0",
         "debug": "^4.1.1",
         "err-code": "^1.1.2",
         "hashlru": "^2.3.0",
         "heap": "~0.2.6",
         "interface-datastore": "~0.6.0",
         "k-bucket": "^5.0.0",
-        "libp2p-crypto": "~0.16.0",
+        "libp2p-crypto": "~0.16.1",
         "libp2p-record": "~0.6.2",
         "merge-options": "^1.0.1",
         "multihashes": "~0.4.14",
@@ -8859,12 +8847,24 @@
         "peer-info": "~0.15.1",
         "priorityqueue": "~0.2.1",
         "protons": "^1.0.1",
-        "pull-length-prefixed": "^1.3.1",
+        "pull-length-prefixed": "^1.3.2",
         "pull-stream": "^3.6.9",
         "varint": "^5.0.0",
         "xor-distance": "^2.0.0"
       },
       "dependencies": {
+        "cids": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.6.0.tgz",
+          "integrity": "sha512-34wuIeiBZOuvBwUuYR4XooVuXUQI2PYU9VmgM2eB3xkSmQYRlv2kh/dIbmGiLY2GuONlGR3lLtYdVkx1G9yXUg==",
+          "dev": true,
+          "requires": {
+            "class-is": "^1.1.0",
+            "multibase": "~0.6.0",
+            "multicodec": "~0.5.0",
+            "multihashes": "~0.4.14"
+          }
+        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -8985,9 +8985,9 @@
           }
         },
         "readable-stream": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.2.0.tgz",
-          "integrity": "sha512-RV20kLjdmpZuTF1INEb9IA3L68Nmi+Ri7ppZqo78wj//Pn62fCoJyV9zalccNzDD/OuJpMG4f+pfMl8+L6QdGw==",
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
+          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -9009,17 +9009,21 @@
       }
     },
     "libp2p-pubsub": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/libp2p-pubsub/-/libp2p-pubsub-0.0.2.tgz",
-      "integrity": "sha512-1/ZzP+QmEG/J1D20JKORar9H1QgNLvFVHnaGPSWt0D4oGtzY790oRSyybYFEV+tkshii/gm74na5UmDHL/1q7g==",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/libp2p-pubsub/-/libp2p-pubsub-0.0.4.tgz",
+      "integrity": "sha512-j6cup6pQ1060Qhn8Lw2wzoGISyvQgvsFNiGngn5Yld8LaHKgP2T6wgJMEe0e69uEa3yqCWxe+QWFO5RcA1AJDw==",
       "dev": true,
       "requires": {
-        "async": "^2.6.1",
+        "async": "^2.6.2",
+        "bs58": "^4.0.1",
         "debug": "^4.1.1",
         "err-code": "^1.1.2",
-        "length-prefixed-stream": "^1.6.0",
+        "length-prefixed-stream": "^2.0.0",
+        "libp2p-crypto": "~0.16.1",
         "protons": "^1.0.1",
+        "pull-length-prefixed": "^1.3.1",
         "pull-pushable": "^2.2.0",
+        "pull-stream": "^3.6.9",
         "time-cache": "~0.3.0"
       },
       "dependencies": {
@@ -9032,11 +9036,33 @@
             "ms": "^2.1.1"
           }
         },
+        "length-prefixed-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/length-prefixed-stream/-/length-prefixed-stream-2.0.0.tgz",
+          "integrity": "sha512-dvjTuWTKWe0oEznQcG6a9osfiYknCs7DEFJMP88n9Y581IFhYh1sZIgAFcuDOojKB0G7ftPreKhh4D0kh/VPjQ==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.1.1",
+            "varint": "^5.0.0"
+          }
+        },
         "ms": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true
+        },
+        "readable-stream": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
+          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
         }
       }
     },
@@ -9580,9 +9606,9 @@
       }
     },
     "mem": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-4.2.0.tgz",
-      "integrity": "sha512-5fJxa68urlY0Ir8ijatKa3eRz5lwXnRCTvo9+TbTGAuTFJOwpGcY0X05moBd0nW45965Njt4CDI2GFQoG8DvqA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+      "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
       "dev": true,
       "requires": {
         "map-age-cleaner": "^0.1.1",
@@ -9684,9 +9710,9 @@
           }
         },
         "readable-stream": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.2.0.tgz",
-          "integrity": "sha512-RV20kLjdmpZuTF1INEb9IA3L68Nmi+Ri7ppZqo78wj//Pn62fCoJyV9zalccNzDD/OuJpMG4f+pfMl8+L6QdGw==",
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
+          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -9734,30 +9760,30 @@
       }
     },
     "mime": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.0.tgz",
-      "integrity": "sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.2.tgz",
+      "integrity": "sha512-zJBfZDkwRu+j3Pdd2aHsR5GfH2jIWhmL1ZzBoc+X+3JEti2hbArWcyJ+1laC1D2/U/W1a/+Cegj0/OnEU2ybjg==",
       "dev": true
     },
     "mime-db": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
-      "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg==",
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.22",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
-      "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+      "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
       "dev": true,
       "requires": {
-        "mime-db": "~1.38.0"
+        "mime-db": "1.40.0"
       }
     },
     "mimic-fn": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.0.0.tgz",
-      "integrity": "sha512-jbex9Yd/3lmICXwYT6gA/j2mNQGU48wCh/VzRd+/Y/PjYQtlg1gLMdZqvu9s/xH7qKvngxRObl56XZR609IMbA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true
     },
     "mimic-response": {
@@ -10039,9 +10065,9 @@
       }
     },
     "multicodec": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-0.5.0.tgz",
-      "integrity": "sha512-lKsJeT4cKeSq0rVEWhO3oSBgDN4sMY1sNZKlvl68g/ZAahjPS1KIVyF4IqhuYmCdtOyKs4Q4hQ6M0C3iqRnuqQ==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-0.5.1.tgz",
+      "integrity": "sha512-Q5glyZLdXVbbBxvRYHLQHpu8ydVf1422Z+v9fU47v2JCkiue7n+JcFS7uRv0cQW8hbVtgdtIDgYWPWaIKEXuXA==",
       "requires": {
         "varint": "^5.0.0"
       }
@@ -10161,9 +10187,9 @@
       }
     },
     "negotiator": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
       "dev": true
     },
     "neo-async": {
@@ -10218,17 +10244,17 @@
       }
     },
     "node-abi": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.7.1.tgz",
-      "integrity": "sha512-OV8Bq1OrPh6z+Y4dqwo05HqrRL9YNF7QVMRfq1/pguwKLG+q9UB/Lk0x5qXjO23JjJg+/jqCHSTaG1P3tfKfuw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.8.0.tgz",
+      "integrity": "sha512-1/aa2clS0pue0HjckL62CsbhWWU35HARvBDXcJtYKbYR7LnIutmpxmXbuDMV9kEviD2lP/wACOgWmmwljghHyQ==",
       "requires": {
         "semver": "^5.4.1"
       }
     },
     "node-fetch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
-      "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.5.0.tgz",
+      "integrity": "sha512-YuZKluhWGJwCcUu4RlZstdAxr8bFfOVHakc1mplwHkk8J+tqM1Y5yraYvIUpeX8aY7+crCwiELJq7Vl0o0LWXw==",
       "dev": true
     },
     "node-forge": {
@@ -10324,9 +10350,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.11.tgz",
-      "integrity": "sha512-8v1j5KfP+s5WOTa1spNUAOfreajQPN12JXbRR0oDE+YrJBQCXBnNqUDj27EKpPLOoSiU3tKi3xGPB+JaOdUEQQ==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.17.tgz",
+      "integrity": "sha512-/SCjetyta1m7YXLgtACZGDYJdCSIBAWorDWkGCGZlydP2Ll7J48l7j/JxNYZ+xsgSPbWfdulVS/aY+GdjUsQ7Q==",
       "dev": true,
       "requires": {
         "semver": "^5.3.0"
@@ -10441,9 +10467,9 @@
       }
     },
     "object-keys": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.0.tgz",
-      "integrity": "sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "dev": true
     },
     "object-visit": {
@@ -10549,44 +10575,12 @@
       "dev": true
     },
     "orbit-db-identity-provider": {
-      "version": "0.1.0-rc.1.2",
-      "resolved": "https://registry.npmjs.org/orbit-db-identity-provider/-/orbit-db-identity-provider-0.1.0-rc.1.2.tgz",
-      "integrity": "sha512-GcfooAdVr/G7nkvRqzE8ZL+w9Tt2dYMvQEC9uBFrYAtI4KMFLc0K9tShu/SlDdymtmWaudTwRBotc32jhukuEA==",
+      "version": "0.1.0-rc2",
+      "resolved": "https://registry.npmjs.org/orbit-db-identity-provider/-/orbit-db-identity-provider-0.1.0-rc2.tgz",
+      "integrity": "sha512-P1+nvPE7D3DHT2Lv+KljijU071EMldGbwEki94kLMTeiXuLRgcnPQwMM1IMBbWmPfUojWNpXS4X+o6ad6tEllA==",
       "requires": {
         "ethers": "^4.0.20",
-        "orbit-db-keystore": "^0.2.0-rc.1.2"
-      },
-      "dependencies": {
-        "elliptic": {
-          "version": "6.4.1",
-          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
-          "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
-          "requires": {
-            "bn.js": "^4.4.0",
-            "brorand": "^1.0.1",
-            "hash.js": "^1.0.0",
-            "hmac-drbg": "^1.0.0",
-            "inherits": "^2.0.1",
-            "minimalistic-assert": "^1.0.0",
-            "minimalistic-crypto-utils": "^1.0.0"
-          }
-        },
-        "orbit-db-keystore": {
-          "version": "0.2.0-rc.1.2",
-          "resolved": "https://registry.npmjs.org/orbit-db-keystore/-/orbit-db-keystore-0.2.0-rc.1.2.tgz",
-          "integrity": "sha512-dSPoJygbnGJGAPVchu3KYWp2fhLezYCz9tHg6EzZB1cMuILN7DGMpM1Q1DsM3deNx2cdhYgEeYUsFJlttJfAPA==",
-          "requires": {
-            "elliptic": "^6.4.1",
-            "level-js": "~3.0.0",
-            "leveldown": "~3.0.2",
-            "levelup": "^4.0.0",
-            "libp2p-crypto": "^0.16.0",
-            "libp2p-crypto-secp256k1": "^0.3.0",
-            "lru": "^3.1.0",
-            "mkdirp": "^0.5.1",
-            "safe-buffer": "^5.1.2"
-          }
-        }
+        "orbit-db-keystore": "^0.2.0-rc2"
       }
     },
     "orbit-db-io": {
@@ -10600,10 +10594,9 @@
       }
     },
     "orbit-db-keystore": {
-      "version": "0.2.0-rc.1",
-      "resolved": "https://registry.npmjs.org/orbit-db-keystore/-/orbit-db-keystore-0.2.0-rc.1.tgz",
-      "integrity": "sha512-VjN3F2SFV8RLhN8iwlTR4QbU5IT3qL7u3dJBF+YeYyblEttSL/cxn/D510WY+NnazJ1WOv+tWOTIFwVrlmvWMQ==",
-      "dev": true,
+      "version": "0.2.0-rc2",
+      "resolved": "https://registry.npmjs.org/orbit-db-keystore/-/orbit-db-keystore-0.2.0-rc2.tgz",
+      "integrity": "sha512-I5T/boyngKCaClKyAwdMWbfaynPF39QHR8suANYJQLsdPE+QlpD34yTJhShUo1Ttph21IlILmS9LqutkDLIDLw==",
       "requires": {
         "elliptic": "^6.4.1",
         "level-js": "~3.0.0",
@@ -10612,14 +10605,14 @@
         "libp2p-crypto": "^0.16.0",
         "libp2p-crypto-secp256k1": "^0.3.0",
         "lru": "^3.1.0",
-        "mkdirp": "^0.5.1"
+        "mkdirp": "^0.5.1",
+        "safe-buffer": "^5.1.2"
       },
       "dependencies": {
         "elliptic": {
           "version": "6.4.1",
           "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
           "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
-          "dev": true,
           "requires": {
             "bn.js": "^4.4.0",
             "brorand": "^1.0.1",
@@ -10684,9 +10677,9 @@
       "dev": true
     },
     "p-is-promise": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.0.0.tgz",
-      "integrity": "sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
+      "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
       "dev": true
     },
     "p-limit": {
@@ -10719,9 +10712,9 @@
       "dev": true
     },
     "p-try": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.1.0.tgz",
-      "integrity": "sha512-H2RyIJ7+A3rjkwKC2l5GGtU4H1vkxKCAGsWasNVd0Set+6i4znxbWy6/j16YDPJDWxhsgZiKAstMEP8wCdSpjA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
     },
     "p-whilst": {
@@ -11185,9 +11178,9 @@
       "dev": true
     },
     "prom-client": {
-      "version": "11.2.1",
-      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-11.2.1.tgz",
-      "integrity": "sha512-7VwtjrkQS50NvDoeYNn2z6wzXB5BMGzUlmMOeLPaITtJsTVXnPywRta7QFiV4pKr0fbRx9oDfUcx1xibabjSAg==",
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-11.3.0.tgz",
+      "integrity": "sha512-OqSf5WOvpGZXkfqPXUHNHpjrbEE/q8jxjktO0i7zg1cnULAtf0ET67/J5R4e4iA4MZx2260tzTzSFSWgMdTZmQ==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -11195,9 +11188,9 @@
       }
     },
     "prometheus-gc-stats": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/prometheus-gc-stats/-/prometheus-gc-stats-0.6.1.tgz",
-      "integrity": "sha512-DUo/cDs+1XcVuqoFU6+DjmWjkjIRIVeswtZAIfslIPrYfli2NK0/g/BPoO/kqOgLvzbKRx4m9+MDeNsNIIJGkg==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/prometheus-gc-stats/-/prometheus-gc-stats-0.6.2.tgz",
+      "integrity": "sha512-ABSVHkAuYrMLj1WHmlLfS0hu9Vc2ELKuecwiMWPNQom+ZNiAdcILTn5yGK7sZg2ttoWc2u++W5NjdJ3IjdYJZw==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -11243,9 +11236,9 @@
       }
     },
     "proper-lockfile": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.0.tgz",
-      "integrity": "sha512-5FGLP4Dehcwd1bOPyQhWKUosdIbL9r7F6uvBYhlsJAsGSwFk4nGtrS1Poqj6cKU2XXgqkqfDw2h0JdNjd8IgIQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.1.tgz",
+      "integrity": "sha512-1w6rxXodisVpn7QYvLk706mzprPTAPCYAqxMvctmPN3ekuRk/kuGkGc82pangZiAt4R3lwSuUzheTTn0/Yb7Zg==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.11",
@@ -11355,14 +11348,14 @@
       }
     },
     "pull-length-prefixed": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/pull-length-prefixed/-/pull-length-prefixed-1.3.1.tgz",
-      "integrity": "sha512-Ho0KoVKOILITGPusghadRVcUzflFHAHcv1Hvi/OkUSJLkGK2LNmVjsmIaJbWkizI//okIj2n376JyTFwCWdsYA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/pull-length-prefixed/-/pull-length-prefixed-1.3.2.tgz",
+      "integrity": "sha512-eHSUxrDNgdbZnfj+96UiG2R8pGmStQ0dW9IuQoUBCCVlC3rIlhUCvv8LJv+FZIQy7ys1LANqUmWmLYqiFxJC+g==",
       "dev": true,
       "requires": {
-        "pull-pushable": "^2.0.1",
-        "pull-reader": "^1.3.0",
-        "safe-buffer": "^5.0.1",
+        "pull-pushable": "^2.2.0",
+        "pull-reader": "^1.3.1",
+        "safe-buffer": "^5.1.2",
         "varint": "^5.0.0"
       }
     },
@@ -11482,18 +11475,18 @@
       }
     },
     "pull-to-stream": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/pull-to-stream/-/pull-to-stream-0.1.0.tgz",
-      "integrity": "sha512-LMvdE0JwT7XQZMFjc7JDl/G9gmoZ8Zo8e86SG4ZZUcjuwvod803KxpAK8WrmdxzHsMRK9DETlIzuA0tbEVv6jg==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pull-to-stream/-/pull-to-stream-0.1.1.tgz",
+      "integrity": "sha512-thZkMv6F9PILt9zdvpI2gxs19mkDrlixYKX6cOBxAW16i1NZH+yLAmF4r8QfJ69zuQh27e01JZP9y27tsH021w==",
       "dev": true,
       "requires": {
         "readable-stream": "^3.1.1"
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.2.0.tgz",
-          "integrity": "sha512-RV20kLjdmpZuTF1INEb9IA3L68Nmi+Ri7ppZqo78wj//Pn62fCoJyV9zalccNzDD/OuJpMG4f+pfMl8+L6QdGw==",
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
+          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -11929,9 +11922,9 @@
       }
     },
     "resolve": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
-      "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.1.tgz",
+      "integrity": "sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
@@ -12191,9 +12184,9 @@
       }
     },
     "serialize-javascript": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.6.1.tgz",
-      "integrity": "sha512-A5MOagrPFga4YaKQSWHryl7AXvbQkEqpw4NNYMTNYUNV51bA8ABHgYFpqKx+YFFrw59xMV1qGH1R4AgoNIVgCw==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.7.0.tgz",
+      "integrity": "sha512-ke8UG8ulpFOxO8f8gRYabHQe/ZntKlcig2Mp+8+URDP1D8vJZ0KUt7LYo07q25Z/+JVSgpr/cui9PIp5H6/+nA==",
       "dev": true
     },
     "set-blocking": {
@@ -12560,6 +12553,12 @@
         "to-array": "0.1.4"
       },
       "dependencies": {
+        "component-emitter": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+          "dev": true
+        },
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -12582,6 +12581,12 @@
         "isarray": "2.0.1"
       },
       "dependencies": {
+        "component-emitter": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+          "dev": true
+        },
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -12686,9 +12691,9 @@
       }
     },
     "source-map-support": {
-      "version": "0.5.11",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.11.tgz",
-      "integrity": "sha512-//sajEx/fGL3iw6fltKMdPvy8kL3kJ2O3iuYlRoT3k9Kb4BjOoZ+BZzaNHeuaruSt+Kf3Zk9tnfAQg9/AJqUVQ==",
+      "version": "0.5.12",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
+      "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
@@ -12742,9 +12747,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
-      "integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz",
+      "integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA==",
       "dev": true
     },
     "split": {
@@ -12929,9 +12934,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.2.0.tgz",
-          "integrity": "sha512-RV20kLjdmpZuTF1INEb9IA3L68Nmi+Ri7ppZqo78wj//Pn62fCoJyV9zalccNzDD/OuJpMG4f+pfMl8+L6QdGw==",
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
+          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -13094,9 +13099,9 @@
           "dev": true
         },
         "readable-stream": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.2.0.tgz",
-          "integrity": "sha512-RV20kLjdmpZuTF1INEb9IA3L68Nmi+Ri7ppZqo78wj//Pn62fCoJyV9zalccNzDD/OuJpMG4f+pfMl8+L6QdGw==",
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
+          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -13169,9 +13174,9 @@
       }
     },
     "tapable": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.1.tgz",
-      "integrity": "sha512-9I2ydhj8Z9veORCw5PRm4u9uebCn0mcCa6scWoNcbZ6dAtoo2618u9UUzxgmsCOreJpqDDuv61LvwofW7hLcBA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
+      "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
       "dev": true
     },
     "tar-fs": {
@@ -13406,16 +13411,16 @@
       "dev": true
     },
     "tiny-secp256k1": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.0.1.tgz",
-      "integrity": "sha512-Wz2kMPWtCI5XBftFeF3bUL8uz2+VlasniKwOkRPjvL7h1QVd9rbhrve/HWUu747kJKzVf1XHonzcdM4Ut8fvww==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.1.0.tgz",
+      "integrity": "sha512-DIl0SCUIVcPrk/oOiq8/YgQ69Beayw4XSW2icyXJN8xfKMmxo5XM8gXVG1Ex+rYsHg2xuEpNFeeU6J4CtqQFrA==",
       "dev": true,
       "requires": {
         "bindings": "^1.3.0",
         "bn.js": "^4.11.8",
         "create-hmac": "^1.1.7",
         "elliptic": "^6.4.0",
-        "nan": "^2.10.0"
+        "nan": "^2.12.1"
       },
       "dependencies": {
         "elliptic": {
@@ -13432,6 +13437,12 @@
             "minimalistic-assert": "^1.0.0",
             "minimalistic-crypto-utils": "^1.0.0"
           }
+        },
+        "nan": {
+          "version": "2.13.2",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
+          "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
+          "dev": true
         }
       }
     },
@@ -13608,13 +13619,13 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.2.tgz",
-      "integrity": "sha512-imog1WIsi9Yb56yRt5TfYVxGmnWs3WSGU73ieSOlMVFwhJCA9W8fqFFMMj4kgDqiS/80LGdsYnWL7O9UcjEBlg==",
+      "version": "3.5.9",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.9.tgz",
+      "integrity": "sha512-WpT0RqsDtAWPNJK955DEnb6xjymR8Fn0OlK4TT4pS0ASYsVPqr5ELhgwOwLCP5J5vHeJ4xmMmz3DEgdqC10JeQ==",
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "~2.19.0",
+        "commander": "~2.20.0",
         "source-map": "~0.6.1"
       },
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -838,9 +838,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.14.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.4.tgz",
-      "integrity": "sha512-DT25xX/YgyPKiHFOpNuANIQIVvYEwCWXgK2jYYwqgaMrYE6+tq+DtmMwlD3drl6DJbUwtlIDnn0d7tIn/EbXBg=="
+      "version": "10.14.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.5.tgz",
+      "integrity": "sha512-Ja7d4s0qyGFxjGeDq5S7Si25OFibSAHUi6i17UWnwNnpitADN7hah9q0Tl25gxuV5R1u2Bx+np6w4LHXfHyj/g=="
     },
     "@webassemblyjs/ast": {
       "version": "1.7.11",
@@ -2809,7 +2809,7 @@
         "datastore-core": "~0.6.0",
         "encoding-down": "^5.0.4",
         "interface-datastore": "~0.6.0",
-        "level-js": "github:timkuijsten/level.js#18e03adab34c49523be7d3d58fafb0c632f61303",
+        "level-js": "github:timkuijsten/level.js#idbunwrapper",
         "leveldown": "^3.0.2",
         "levelup": "^2.0.2",
         "pull-stream": "^3.6.9"
@@ -4601,7 +4601,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4622,12 +4623,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4642,17 +4645,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4769,7 +4775,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4781,6 +4788,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4795,6 +4803,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4802,12 +4811,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4826,6 +4837,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4906,7 +4918,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4918,6 +4931,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5003,7 +5017,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5039,6 +5054,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5058,6 +5074,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5101,12 +5118,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -5181,7 +5200,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5202,12 +5222,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5222,17 +5244,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5349,7 +5374,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5361,6 +5387,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5375,6 +5402,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5382,12 +5410,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5406,6 +5436,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5494,7 +5525,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5506,6 +5538,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5591,7 +5624,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5621,6 +5655,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5640,6 +5675,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5683,12 +5719,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -6015,6 +6053,16 @@
         "topo": "2.x.x"
       },
       "dependencies": {
+        "ammo": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/ammo/-/ammo-2.0.4.tgz",
+          "integrity": "sha1-v4CqshFpjqePY+9efxE91dnokX8=",
+          "dev": true,
+          "requires": {
+            "boom": "5.x.x",
+            "hoek": "4.x.x"
+          }
+        },
         "boom": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
@@ -6048,6 +6096,20 @@
             "hoek": "4.x.x",
             "isemail": "3.x.x",
             "topo": "2.x.x"
+          }
+        },
+        "teamwork": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/teamwork/-/teamwork-3.0.3.tgz",
+          "integrity": "sha512-OCB56z+G70iA1A1OFoT+51TPzfcgN0ks75uN3yhxA+EU66WTz2BevNDK4YzMqfaL5tuAvxy4iFUn35/u8pxMaQ=="
+        },
+        "topo": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
+          "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
+          "dev": true,
+          "requires": {
+            "hoek": "4.x.x"
           }
         }
       }
@@ -7251,7 +7313,6 @@
         "concat-stream": {
           "version": "github:hugomrdias/concat-stream#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
           "from": "github:hugomrdias/concat-stream#feat/smaller",
-          "dev": true,
           "requires": {
             "inherits": "^2.0.3",
             "readable-stream": "^3.0.2"
@@ -7277,7 +7338,7 @@
             "bl": "^3.0.0",
             "bs58": "^4.0.1",
             "cids": "~0.5.5",
-            "concat-stream": "github:hugomrdias/concat-stream#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
+            "concat-stream": "github:hugomrdias/concat-stream#feat/smaller",
             "debug": "^4.1.0",
             "detect-node": "^2.0.4",
             "end-of-stream": "^1.4.1",
@@ -7299,7 +7360,7 @@
             "multibase": "~0.6.0",
             "multicodec": "~0.5.0",
             "multihashes": "~0.4.14",
-            "ndjson": "github:hugomrdias/ndjson#4db16da6b42e5b39bf300c3a7cde62abb3fa3a11",
+            "ndjson": "github:hugomrdias/ndjson#feat/readable-stream3",
             "once": "^1.4.0",
             "peer-id": "~0.12.2",
             "peer-info": "~0.15.1",
@@ -7313,6 +7374,39 @@
             "stream-to-pull-stream": "^1.7.2",
             "tar-stream": "^2.0.1",
             "through2": "^3.0.1"
+          },
+          "dependencies": {
+            "concat-stream": {
+              "version": "github:hugomrdias/concat-stream#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
+              "from": "github:hugomrdias/concat-stream#feat/smaller",
+              "dev": true,
+              "requires": {
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.0.2"
+              }
+            },
+            "ndjson": {
+              "version": "github:hugomrdias/ndjson#4db16da6b42e5b39bf300c3a7cde62abb3fa3a11",
+              "from": "github:hugomrdias/ndjson#feat/readable-stream3",
+              "dev": true,
+              "requires": {
+                "json-stringify-safe": "^5.0.1",
+                "minimist": "^1.2.0",
+                "split2": "^3.1.0",
+                "through2": "^3.0.0"
+              },
+              "dependencies": {
+                "split2": {
+                  "version": "3.1.1",
+                  "resolved": "https://registry.npmjs.org/split2/-/split2-3.1.1.tgz",
+                  "integrity": "sha512-emNzr1s7ruq4N+1993yht631/JH+jaj0NYBosuKmLcq+JkGQ9MmTw1RB1fGaTCzUuseRIClrlSLHRNYGwWQ58Q==",
+                  "dev": true,
+                  "requires": {
+                    "readable-stream": "^3.0.0"
+                  }
+                }
+              }
+            }
           }
         },
         "ms": {
@@ -7324,11 +7418,9 @@
         "ndjson": {
           "version": "github:hugomrdias/ndjson#4db16da6b42e5b39bf300c3a7cde62abb3fa3a11",
           "from": "github:hugomrdias/ndjson#feat/readable-stream3",
-          "dev": true,
           "requires": {
             "json-stringify-safe": "^5.0.1",
             "minimist": "^1.2.0",
-            "split2": "^3.1.0",
             "through2": "^3.0.0"
           }
         },
@@ -7346,20 +7438,10 @@
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.2.0.tgz",
           "integrity": "sha512-RV20kLjdmpZuTF1INEb9IA3L68Nmi+Ri7ppZqo78wj//Pn62fCoJyV9zalccNzDD/OuJpMG4f+pfMl8+L6QdGw==",
-          "dev": true,
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
             "util-deprecate": "^1.0.1"
-          }
-        },
-        "split2": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/split2/-/split2-3.1.1.tgz",
-          "integrity": "sha512-emNzr1s7ruq4N+1993yht631/JH+jaj0NYBosuKmLcq+JkGQ9MmTw1RB1fGaTCzUuseRIClrlSLHRNYGwWQ58Q==",
-          "dev": true,
-          "requires": {
-            "readable-stream": "^3.0.0"
           }
         },
         "tar-stream": {
@@ -7379,7 +7461,6 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
           "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
-          "dev": true,
           "requires": {
             "readable-stream": "2 || 3"
           }
@@ -8161,8 +8242,7 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json-text-sequence": {
       "version": "0.1.1",
@@ -9130,7 +9210,7 @@
         "socket.io": "^2.1.1",
         "socket.io-client": "^2.1.1",
         "stream-to-pull-stream": "^1.7.2",
-        "webrtcsupport": "github:ipfs/webrtcsupport#0669f576582c53a3a42aa5ac014fcc5966809615"
+        "webrtcsupport": "github:ipfs/webrtcsupport"
       },
       "dependencies": {
         "debug": {
@@ -9231,7 +9311,7 @@
         "interface-connection": "~0.3.2",
         "mafmt": "^6.0.4",
         "multiaddr-to-uri": "^4.0.1",
-        "pull-ws": "github:hugomrdias/pull-ws#8e2ce0bb3b1cd6804828316e937fff8e0bef6225"
+        "pull-ws": "github:hugomrdias/pull-ws#fix/bundle-size"
       },
       "dependencies": {
         "debug": {
@@ -10469,11 +10549,44 @@
       "dev": true
     },
     "orbit-db-identity-provider": {
-      "version": "github:orbitdb/orbit-db-identity-provider#fc0829fefc855f3299b681acf6c76b48ce158a50",
-      "from": "github:orbitdb/orbit-db-identity-provider#libp2p",
+      "version": "0.1.0-rc.1.2",
+      "resolved": "https://registry.npmjs.org/orbit-db-identity-provider/-/orbit-db-identity-provider-0.1.0-rc.1.2.tgz",
+      "integrity": "sha512-GcfooAdVr/G7nkvRqzE8ZL+w9Tt2dYMvQEC9uBFrYAtI4KMFLc0K9tShu/SlDdymtmWaudTwRBotc32jhukuEA==",
       "requires": {
         "ethers": "^4.0.20",
-        "orbit-db-keystore": "github:orbitdb/orbit-db-keystore#a7e6771692de8c17417a83473dd8f962d2cf5c36"
+        "orbit-db-keystore": "^0.2.0-rc.1.2"
+      },
+      "dependencies": {
+        "elliptic": {
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
+          "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
+          "requires": {
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.0"
+          }
+        },
+        "orbit-db-keystore": {
+          "version": "0.2.0-rc.1.2",
+          "resolved": "https://registry.npmjs.org/orbit-db-keystore/-/orbit-db-keystore-0.2.0-rc.1.2.tgz",
+          "integrity": "sha512-dSPoJygbnGJGAPVchu3KYWp2fhLezYCz9tHg6EzZB1cMuILN7DGMpM1Q1DsM3deNx2cdhYgEeYUsFJlttJfAPA==",
+          "requires": {
+            "elliptic": "^6.4.1",
+            "level-js": "~3.0.0",
+            "leveldown": "~3.0.2",
+            "levelup": "^4.0.0",
+            "libp2p-crypto": "^0.16.0",
+            "libp2p-crypto-secp256k1": "^0.3.0",
+            "lru": "^3.1.0",
+            "mkdirp": "^0.5.1",
+            "safe-buffer": "^5.1.2"
+          }
+        }
       }
     },
     "orbit-db-io": {
@@ -10487,8 +10600,10 @@
       }
     },
     "orbit-db-keystore": {
-      "version": "github:orbitdb/orbit-db-keystore#a7e6771692de8c17417a83473dd8f962d2cf5c36",
-      "from": "github:orbitdb/orbit-db-keystore#libp2p",
+      "version": "0.2.0-rc.1",
+      "resolved": "https://registry.npmjs.org/orbit-db-keystore/-/orbit-db-keystore-0.2.0-rc.1.tgz",
+      "integrity": "sha512-VjN3F2SFV8RLhN8iwlTR4QbU5IT3qL7u3dJBF+YeYyblEttSL/cxn/D510WY+NnazJ1WOv+tWOTIFwVrlmvWMQ==",
+      "dev": true,
       "requires": {
         "elliptic": "^6.4.1",
         "level-js": "~3.0.0",
@@ -10504,6 +10619,7 @@
           "version": "6.4.1",
           "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
           "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
+          "dev": true,
           "requires": {
             "bn.js": "^4.4.0",
             "brorand": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "cids": "^0.5.7",
     "ipld-dag-pb": "^0.15.2",
-    "orbit-db-identity-provider": "rc1",
+    "orbit-db-identity-provider": "next",
     "orbit-db-io": "~0.0.1",
     "p-map": "^1.1.1",
     "p-whilst": "^1.0.0",

--- a/src/log-errors.js
+++ b/src/log-errors.js
@@ -5,7 +5,7 @@ const LogNotDefinedError = () => new Error('Log instance not defined')
 const NotALogError = () => new Error('Given argument is not an instance of Log')
 const CannotJoinWithDifferentId = () => new Error('Can\'t join logs with different IDs')
 const LtOrLteMustBeStringOrArray = () => new Error('lt or lte must be a string or array of Entries')
-const NeedToUpgrade = () => new Error("Append is now disabled in OrbitDB 0.19. Please upgrade to the latest version.")
+const NeedToUpgrade = () => new Error('Append is now disabled in OrbitDB 0.19. Please upgrade to the latest version.')
 
 module.exports = {
   IPFSNotDefinedError: IPFSNotDefinedError,

--- a/src/log-errors.js
+++ b/src/log-errors.js
@@ -5,11 +5,13 @@ const LogNotDefinedError = () => new Error('Log instance not defined')
 const NotALogError = () => new Error('Given argument is not an instance of Log')
 const CannotJoinWithDifferentId = () => new Error('Can\'t join logs with different IDs')
 const LtOrLteMustBeStringOrArray = () => new Error('lt or lte must be a string or array of Entries')
+const NeedToUpgrade = () => new Error("Append is now disabled in OrbitDB 0.19. Please upgrade to the latest version.")
 
 module.exports = {
   IPFSNotDefinedError: IPFSNotDefinedError,
   LogNotDefinedError: LogNotDefinedError,
   NotALogError: NotALogError,
   CannotJoinWithDifferentId: CannotJoinWithDifferentId,
-  LtOrLteMustBeStringOrArray: LtOrLteMustBeStringOrArray
+  LtOrLteMustBeStringOrArray: LtOrLteMustBeStringOrArray,
+  NeedToUpgrade: NeedToUpgrade
 }

--- a/src/log.js
+++ b/src/log.js
@@ -240,7 +240,7 @@ class Log extends GSet {
    * @return {Log} New Log containing the appended value
    */
   async append () {
-    throw new Error("Append is now disabled in OrbitDB 0.19. Please upgrade to the latest version.")
+    throw new LogError.NeedToUpgrade()
   }
 
   /*
@@ -329,7 +329,7 @@ class Log extends GSet {
     const permitted = async (entry) => {
       const canAppend = await this._access.canAppend(entry, identityProvider)
       if (!canAppend) {
-        throw new LogError.NeedToUpgrade()
+        throw new Error(`Could not append entry, key "${entry.identity.id}" is not allowed to write to the log`)
       }
     }
 

--- a/src/log.js
+++ b/src/log.js
@@ -329,7 +329,7 @@ class Log extends GSet {
     const permitted = async (entry) => {
       const canAppend = await this._access.canAppend(entry, identityProvider)
       if (!canAppend) {
-        throw new Error(`Could not append entry, key "${entry.identity.id}" is not allowed to write to the log`)
+        throw new LogError.NeedToUpgrade()
       }
     }
 

--- a/src/log.js
+++ b/src/log.js
@@ -239,38 +239,8 @@ class Log extends GSet {
    * @param {Entry} entry Entry to add
    * @return {Log} New Log containing the appended value
    */
-  async append (data, pointerCount = 1) {
-    // Update the clock (find the latest clock)
-    const newTime = Math.max(this.clock.time, this.heads.reduce(maxClockTimeReducer, 0)) + 1
-    this._clock = new Clock(this.clock.id, newTime)
-
-    // Get the required amount of cids to next entries (as per current state of the log)
-    const references = this.traverse(this.heads, Math.max(pointerCount, this.heads.length))
-    const nexts = Object.keys(Object.assign({}, this._headsIndex, references))
-
-    // @TODO: Split Entry.create into creating object, checking permission, signing and then posting to IPFS
-    // Create the entry and add it to the internal cache
-    const entry = await Entry.create(
-      this._storage,
-      this._identity,
-      this.id,
-      data,
-      nexts,
-      this.clock
-    )
-
-    const canAppend = await this._access.canAppend(entry, this._identity.provider)
-    if (!canAppend) {
-      throw new Error(`Could not append entry, key "${this._identity.id}" is not allowed to write to the log`)
-    }
-
-    this._entryIndex[entry.cid] = entry
-    nexts.forEach(e => (this._nextsIndex[e] = entry.cid))
-    this._headsIndex = {}
-    this._headsIndex[entry.cid] = entry
-    // Update the length
-    this._length++
-    return entry
+  async append () {
+    throw new Error("Append is now disabled in OrbitDB 0.19. Please upgrade to the latest version.")
   }
 
   /*

--- a/test/entry-io.spec.js
+++ b/test/entry-io.spec.js
@@ -48,7 +48,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
       rmrf.sync(signingKeysPath)
     })
 
-    it('log with one entry', async () => {
+    it.skip('log with one entry', async () => {
       let log = new Log(ipfs, testIdentity, { logId: 'X' })
       await log.append('one')
       const cid = log.values[0].cid
@@ -56,7 +56,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
       assert.strictEqual(res.length, 1)
     })
 
-    it('log with 2 entries', async () => {
+    it.skip('log with 2 entries', async () => {
       let log = new Log(ipfs, testIdentity, { logId: 'X' })
       await log.append('one')
       await log.append('two')
@@ -65,7 +65,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
       assert.strictEqual(res.length, 2)
     })
 
-    it('loads max 1 entry from a log of 2 entry', async () => {
+    it.skip('loads max 1 entry from a log of 2 entry', async () => {
       let log = new Log(ipfs, testIdentity, { logId: 'X' })
       await log.append('one')
       await log.append('two')
@@ -74,7 +74,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
       assert.strictEqual(res.length, 1)
     })
 
-    it('log with 100 entries', async () => {
+    it.skip('log with 100 entries', async () => {
       const count = 100
       let log = new Log(ipfs, testIdentity, { logId: 'X' })
       for (let i = 0; i < count; i++) {
@@ -86,7 +86,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
       assert.strictEqual(result.length, count)
     })
 
-    it('load only 42 entries from a log with 100 entries', async () => {
+    it.skip('load only 42 entries from a log with 100 entries', async () => {
       const count = 100
       let log = new Log(ipfs, testIdentity, { logId: 'X' })
       let log2 = new Log(ipfs, testIdentity, { logId: 'X' })
@@ -104,7 +104,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
       assert.strictEqual(result.length, 42)
     })
 
-    it('load only 99 entries from a log with 100 entries', async () => {
+    it.skip('load only 99 entries from a log with 100 entries', async () => {
       const count = 100
       let log = new Log(ipfs, testIdentity, { logId: 'X' })
       let log2 = new Log(ipfs, testIdentity, { logId: 'X' })
@@ -122,7 +122,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
       assert.strictEqual(result.length, 99)
     })
 
-    it('load only 10 entries from a log with 100 entries', async () => {
+    it.skip('load only 10 entries from a log with 100 entries', async () => {
       const count = 100
       let log = new Log(ipfs, testIdentity, { logId: 'X' })
       let log2 = new Log(ipfs, testIdentity, { logId: 'X' })
@@ -148,7 +148,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
       assert.strictEqual(result.length, 10)
     })
 
-    it('load only 10 entries and then expand to max from a log with 100 entries', async () => {
+    it.skip('load only 10 entries and then expand to max from a log with 100 entries', async () => {
       const count = 30
 
       let log = new Log(ipfs, testIdentity, { logId: 'X' })

--- a/test/entry.spec.js
+++ b/test/entry.spec.js
@@ -49,7 +49,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
     })
 
     describe('create', () => {
-      it('creates a an empty entry', async () => {
+      it.skip('creates a an empty entry', async () => {
         const expectedCid = 'zdpuB1cRDqfpXeTJxQCakeUAcBHvgUysVwsnNz3C5bMrcgyT6'
         const entry = await Entry.create(ipfs, testIdentity, 'A', 'hello')
         assert.strictEqual(entry.cid, expectedCid)
@@ -61,7 +61,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
         assert.strictEqual(entry.next.length, 0)
       })
 
-      it('creates a entry with payload', async () => {
+      it.skip('creates a entry with payload', async () => {
         const expectedCid = 'zdpuArMRv55to941Bts4cb8KYD1ERLVyG4wsGCCAtDgHGpZq6'
         const payload = 'hello world'
         const entry = await Entry.create(ipfs, testIdentity, 'A', payload, [])
@@ -74,7 +74,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
         assert.strictEqual(entry.cid, expectedCid)
       })
 
-      it('creates a entry with payload and next', async () => {
+      it.skip('creates a entry with payload and next', async () => {
         const expectedCid = 'zdpuApdx9vqbXA8mbgFs2hNFeR9F6j7fU6v9eB15v1o6cwmbR'
         const payload1 = 'hello world'
         const payload2 = 'hello again'
@@ -88,7 +88,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
         assert.strictEqual(entry2.clock.time, 1)
       })
 
-      it('should return an entry interopable with older versions', async () => {
+      it.skip('should return an entry interopable with older versions', async () => {
         const expectedCid = 'zdpuB1cRDqfpXeTJxQCakeUAcBHvgUysVwsnNz3C5bMrcgyT6'
         const entry = await Entry.create(ipfs, testIdentity, 'A', 'hello')
         assert.strictEqual(entry.cid, entry.hash)
@@ -165,7 +165,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
     })
 
     describe('toCID', () => {
-      it('returns an ipfs CID', async () => {
+      it.skip('returns an ipfs CID', async () => {
         const expectedCid = 'zdpuB1cRDqfpXeTJxQCakeUAcBHvgUysVwsnNz3C5bMrcgyT6'
         const entry = await Entry.create(ipfs, testIdentity, 'A', 'hello', [])
         const cid = await Entry.toCID(ipfs, entry)
@@ -212,7 +212,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
     })
 
     describe('toMultihash', () => {
-      it('returns an ipfs multihash', async () => {
+      it.skip('returns an ipfs multihash', async () => {
         const expectedMultihash = 'QmZDupBAWDNQyooF4uA5WqS2Hu29RtdwmfyYFtRiukWhun'
         const entry = await Entry.create(ipfs, testIdentity, 'A', 'hello', [])
         const multihash = await Entry.toMultihash(ipfs, entry)
@@ -258,7 +258,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
     })
 
     describe('fromCID', () => {
-      it('creates a entry from ipfs CID', async () => {
+      it.skip('creates a entry from ipfs CID', async () => {
         const expectedCid = 'zdpuAsV3NwsbADQ98NKpVRh1HDw14PJH7hMXuvUKH9LDBW5Uw'
         const payload1 = 'hello world'
         const payload2 = 'hello again'
@@ -290,7 +290,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
         assert.strictEqual(final.cid, expectedCid)
       })
 
-      it('should return an entry interopable with older and newer versions', async () => {
+      it.skip('should return an entry interopable with older and newer versions', async () => {
         const expectedCidV1 = 'zdpuB1cRDqfpXeTJxQCakeUAcBHvgUysVwsnNz3C5bMrcgyT6'
         const entryV1 = await Entry.create(ipfs, testIdentity, 'A', 'hello', [])
         const finalV1 = await Entry.fromCID(ipfs, entryV1.cid)

--- a/test/log-append.spec.js
+++ b/test/log-append.spec.js
@@ -43,7 +43,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
     })
 
     describe('append', () => {
-      describe('append one', async () => {
+      describe.skip('append one', async () => {
         let log
 
         before(async () => {
@@ -81,7 +81,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
         })
       })
 
-      describe('append 100 items to a log', async () => {
+      describe.skip('append 100 items to a log', async () => {
         const amount = 100
         const nextPointerAmount = 64
 

--- a/test/log-crdt.spec.js
+++ b/test/log-crdt.spec.js
@@ -17,7 +17,7 @@ const {
 let ipfs, testIdentity, testIdentity2, testIdentity3
 
 Object.keys(testAPIs).forEach((IPFS) => {
-  describe('Log - CRDT (' + IPFS + ')', function () {
+  describe.skip('Log - CRDT (' + IPFS + ')', function () {
     this.timeout(config.timeout)
 
     const { identityKeyFixtures, signingKeyFixtures, identityKeysPath, signingKeysPath } = config

--- a/test/log-heads-tails.spec.js
+++ b/test/log-heads-tails.spec.js
@@ -22,7 +22,7 @@ const last = (arr) => {
 }
 
 Object.keys(testAPIs).forEach((IPFS) => {
-  describe('Log - Heads and Tails (' + IPFS + ')', function () {
+  describe.skip('Log - Heads and Tails (' + IPFS + ')', function () {
     this.timeout(config.timeout)
 
     const { identityKeyFixtures, signingKeyFixtures, identityKeysPath, signingKeysPath } = config

--- a/test/log-iterator.spec.js
+++ b/test/log-iterator.spec.js
@@ -18,7 +18,7 @@ const {
 let ipfs, testIdentity, testIdentity2, testIdentity3
 
 Object.keys(testAPIs).forEach((IPFS) => {
-  describe('Log - Iterator (' + IPFS + ')', function () {
+  describe.skip('Log - Iterator (' + IPFS + ')', function () {
     this.timeout(config.timeout)
 
     const { identityKeyFixtures, signingKeyFixtures, identityKeysPath, signingKeysPath } = config

--- a/test/log-join.spec.js
+++ b/test/log-join.spec.js
@@ -117,7 +117,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
         assert.strictEqual(err.message, 'Given argument is not an instance of Log')
       })
 
-      it('joins only unique items', async () => {
+      it.skip('joins only unique items', async () => {
         await log1.append('helloA1')
         await log1.append('helloA2')
         await log2.append('helloB1')
@@ -136,7 +136,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
         assert.strictEqual(item.next.length, 1)
       })
 
-      it('joins logs two ways', async () => {
+      it.skip('joins logs two ways', async () => {
         await log1.append('helloA1')
         await log1.append('helloA2')
         await log2.append('helloB1')
@@ -153,7 +153,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
         assert.deepStrictEqual(log2.values.map((e) => e.payload), expectedData)
       })
 
-      it('joins logs twice', async () => {
+      it.skip('joins logs twice', async () => {
         await log1.append('helloA1')
         await log2.append('helloB1')
         await log2.join(log1)
@@ -170,7 +170,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
         assert.deepStrictEqual(log2.values.map((e) => e.payload), expectedData)
       })
 
-      it('joins 2 logs two ways', async () => {
+      it.skip('joins 2 logs two ways', async () => {
         await log1.append('helloA1')
         await log2.append('helloB1')
         await log2.join(log1)
@@ -187,7 +187,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
         assert.deepStrictEqual(log2.values.map((e) => e.payload), expectedData)
       })
 
-      it('joins 2 logs two ways and has the right heads at every step', async () => {
+      it.skip('joins 2 logs two ways and has the right heads at every step', async () => {
         await log1.append('helloA1')
         assert.strictEqual(log1.heads.length, 1)
         assert.strictEqual(log1.heads[0].payload, 'helloA1')
@@ -220,7 +220,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
         assert.strictEqual(log2.heads[1].payload, 'helloA2')
       })
 
-      it('joins 4 logs to one', async () => {
+      it.skip('joins 4 logs to one', async () => {
         // order determined by identity's publicKey
         await log1.append('helloA1')
         await log1.append('helloA2')
@@ -252,7 +252,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
         assert.deepStrictEqual(log1.values.map(e => e.payload), expectedData)
       })
 
-      it('joins 4 logs to one is commutative', async () => {
+      it.skip('joins 4 logs to one is commutative', async () => {
         await log1.append('helloA1')
         await log1.append('helloA2')
         await log2.append('helloB1')
@@ -272,7 +272,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
         assert.deepStrictEqual(log1.values.map(e => e.payload), log2.values.map(e => e.payload))
       })
 
-      it('joins logs and updates clocks', async () => {
+      it.skip('joins logs and updates clocks', async () => {
         await log1.append('helloA1')
         await log2.append('helloB1')
         await log2.join(log1)
@@ -336,7 +336,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
         assert.deepStrictEqual(transformed, expectedData)
       })
 
-      it('joins logs from 4 logs', async () => {
+      it.skip('joins logs from 4 logs', async () => {
         await log1.append('helloA1')
         await log1.join(log2)
         await log2.append('helloB1')
@@ -386,7 +386,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
         assert.deepStrictEqual(log4.values.map((e) => e.payload), expectedData)
       })
 
-      describe('takes length as an argument', async () => {
+      describe.skip('takes length as an argument', async () => {
         beforeEach(async () => {
           await log1.append('helloA1')
           await log1.append('helloA2')

--- a/test/log-load.spec.js
+++ b/test/log-load.spec.js
@@ -69,7 +69,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
       rmrf.sync(signingKeysPath)
     })
 
-    describe('fromJSON', () => {
+    describe.skip('fromJSON', () => {
       let identities
 
       before(async () => {
@@ -106,7 +106,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
       })
     })
 
-    describe('fromEntryCID', () => {
+    describe.skip('fromEntryCID', () => {
       let identities
 
       before(async () => {
@@ -155,7 +155,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
         identities = [testIdentity3, testIdentity2, testIdentity, testIdentity4]
       })
 
-      it('creates a log from an entry', async () => {
+      it.skip('creates a log from an entry', async () => {
         let fixture = await LogCreator.createLogWithSixteenEntries(ipfs, identities)
         let data = fixture.log
 
@@ -165,7 +165,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
         assert.deepStrictEqual(log.values.map(e => e.payload), fixture.expectedData)
       })
 
-      it('creates a log from an entry with custom tiebreaker', async () => {
+      it.skip('creates a log from an entry with custom tiebreaker', async () => {
         let fixture = await LogCreator.createLogWithSixteenEntries(ipfs, identities)
         let data = fixture.log
 
@@ -176,7 +176,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
         assert.deepStrictEqual(log.values.map(e => e.payload), firstWriteExpectedData)
       })
 
-      it('keeps the original heads', async () => {
+      it.skip('keeps the original heads', async () => {
         let fixture = await LogCreator.createLogWithSixteenEntries(ipfs, identities)
         let data = fixture.log
 
@@ -231,7 +231,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
           { length: -1, exclude: [], onProgressCallback: callback })
       })
 
-      it('retrieves partial log from an entry CID', async () => {
+      it.skip('retrieves partial log from an entry CID', async () => {
         const log1 = new Log(ipfs, testIdentity, { logId: 'X' })
         const log2 = new Log(ipfs, testIdentity2, { logId: 'X' })
         const log3 = new Log(ipfs, testIdentity3, { logId: 'X' })
@@ -344,7 +344,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
         assert.strictEqual(c.length, amount * 3)
       })
 
-      it('retrieves full log from an entry CID 3', async () => {
+      it.skip('retrieves full log from an entry CID 3', async () => {
         const log1 = new Log(ipfs, testIdentity, { logId: 'X' })
         const log2 = new Log(ipfs, testIdentity2, { logId: 'X' })
         const log3 = new Log(ipfs, testIdentity4, { logId: 'X' })
@@ -467,7 +467,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
         assert.strictEqual(g.toString(), bigLogString)
       })
 
-      it('retrieves full log of randomly joined log', async () => {
+      it.skip('retrieves full log of randomly joined log', async () => {
         let log1 = new Log(ipfs, testIdentity, { logId: 'X' })
         let log2 = new Log(ipfs, testIdentity3, { logId: 'X' })
         let log3 = new Log(ipfs, testIdentity4, { logId: 'X' })
@@ -504,7 +504,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
         assert.deepStrictEqual(log1.values.map(e => e.payload), expectedData)
       })
 
-      it('retrieves randomly joined log deterministically', async () => {
+      it.skip('retrieves randomly joined log deterministically', async () => {
         let logA = new Log(ipfs, testIdentity, { logId: 'X' })
         let logB = new Log(ipfs, testIdentity3, { logId: 'X' })
         let log3 = new Log(ipfs, testIdentity4, { logId: 'X' })
@@ -540,7 +540,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
         assert.deepStrictEqual(log.values.map(e => e.payload), expectedData)
       })
 
-      it('sorts', async () => {
+      it.skip('sorts', async () => {
         let testLog = await LogCreator.createLogWithSixteenEntries(ipfs, identities)
         let log = testLog.log
         const expectedData = testLog.expectedData
@@ -589,7 +589,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
         assert.deepStrictEqual(partialLog3.map(e => e.payload), expectedData4)
       })
 
-      it('sorts deterministically from random order', async () => {
+      it.skip('sorts deterministically from random order', async () => {
         let testLog = await LogCreator.createLogWithSixteenEntries(ipfs, identities)
         let log = testLog.log
         const expectedData = testLog.expectedData
@@ -605,14 +605,14 @@ Object.keys(testAPIs).forEach((IPFS) => {
         }
       })
 
-      it('sorts entries correctly', async () => {
+      it.skip('sorts entries correctly', async () => {
         let testLog = await LogCreator.createLogWithTwoHundredEntries(ipfs, identities)
         let log = testLog.log
         const expectedData = testLog.expectedData
         assert.deepStrictEqual(log.values.map(e => e.payload), expectedData)
       })
 
-      it('sorts entries according to custom tiebreaker function', async () => {
+      it.skip('sorts entries according to custom tiebreaker function', async () => {
         let testLog = await LogCreator.createLogWithSixteenEntries(ipfs, identities)
 
         let firstWriteWinsLog =
@@ -622,7 +622,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
           firstWriteExpectedData)
       })
 
-      it('throws an error if the tiebreaker returns zero', async () => {
+      it.skip('throws an error if the tiebreaker returns zero', async () => {
         let testLog = await LogCreator.createLogWithSixteenEntries(ipfs, identities)
         let firstWriteWinsLog =
           new Log(ipfs, identities[0], { logId: 'X', sortFn: BadComparatorReturnsZero })
@@ -630,7 +630,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
         assert.throws(() => firstWriteWinsLog.values, Error, 'Error Thrown')
       })
 
-      it('retrieves partially joined log deterministically - single next pointer', async () => {
+      it.skip('retrieves partially joined log deterministically - single next pointer', async () => {
         const nextPointerAmount = 1
 
         let logA = new Log(ipfs, testIdentity, { logId: 'X' })
@@ -694,7 +694,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
         assert.deepStrictEqual(res.values.map(e => e.payload), all)
       })
 
-      it('retrieves partially joined log deterministically - multiple next pointers', async () => {
+      it.skip('retrieves partially joined log deterministically - multiple next pointers', async () => {
         const nextPointersAmount = 64
 
         let logA = new Log(ipfs, testIdentity, { logId: 'X' })
@@ -806,14 +806,14 @@ Object.keys(testAPIs).forEach((IPFS) => {
           }
         })
 
-        it('returns all entries - no excluded entries', async () => {
+        it.skip('returns all entries - no excluded entries', async () => {
           const a = await Log.fromEntry(ipfs, testIdentity, last(items1),
             { length: -1 })
           assert.strictEqual(a.length, amount)
           assert.strictEqual(a.values[0].cid, items1[0].cid)
         })
 
-        it('returns all entries - including excluded entries', async () => {
+        it.skip('returns all entries - including excluded entries', async () => {
           // One entry
           const a = await Log.fromEntry(ipfs, testIdentity, last(items1),
             { length: -1, exclude: [items1[0]] })

--- a/test/log.spec.js
+++ b/test/log.spec.js
@@ -169,7 +169,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
       })
     })
 
-    describe('toString', async () => {
+    describe.skip('toString', async () => {
       let log
       const expectedData = 'five\n└─four\n  └─three\n    └─two\n      └─one'
 
@@ -187,7 +187,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
       })
     })
 
-    describe('get', async () => {
+    describe.skip('get', async () => {
       let log
 
       beforeEach(async () => {
@@ -206,7 +206,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
       })
     })
 
-    describe('has', async () => {
+    describe.skip('has', async () => {
       let log, expectedData
 
       before(async () => {
@@ -242,7 +242,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
       })
     })
 
-    describe('serialize', async () => {
+    describe.skip('serialize', async () => {
       let log//, testIdentity2, testIdentity3, testIdentity4
       const expectedData = {
         id: 'AAA',
@@ -636,7 +636,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
       })
     })
 
-    describe('values', () => {
+    describe.skip('values', () => {
       it('returns all entries in the log', async () => {
         let log = new Log(ipfs, testIdentity)
         assert.strictEqual(log.values instanceof Array, true)

--- a/test/replicate.spec.js
+++ b/test/replicate.spec.js
@@ -18,7 +18,7 @@ const {
 } = require('./utils')
 
 Object.keys(testAPIs).forEach((IPFS) => {
-  describe('ipfs-log - Replication (' + IPFS + ')', function () {
+  describe.skip('ipfs-log - Replication (' + IPFS + ')', function () {
     this.timeout(config.timeout)
 
     let ipfs1, ipfs2, id1, id2, testIdentity, testIdentity2

--- a/test/signed-log.spec.js
+++ b/test/signed-log.spec.js
@@ -50,7 +50,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
       assert.strictEqual(log.id, logId)
     })
 
-    it('has the correct identity', () => {
+    it.skip('has the correct identity', () => {
       const log = new Log(ipfs, testIdentity, { logId: 'A' })
       assert.notStrictEqual(log.id, null)
       assert.strictEqual(log._identity.id, '03e0480538c2a39951d054e17ff31fde487cb1031d0044a037b53ad2e028a3e77c')
@@ -69,19 +69,19 @@ Object.keys(testAPIs).forEach((IPFS) => {
       assert.strictEqual(log._identity.signatures.id, testIdentity.signatures.id)
     })
 
-    it('has the correct signature', () => {
+    it.skip('has the correct signature', () => {
       const log = new Log(ipfs, testIdentity, { logId: 'A' })
       assert.strictEqual(log._identity.signatures.publicKey, testIdentity.signatures.publicKey)
     })
 
-    it('entries contain an identity', async () => {
+    it.skip('entries contain an identity', async () => {
       const log = new Log(ipfs, testIdentity, { logId: 'A' })
       await log.append('one')
       assert.notStrictEqual(log.values[0].sig, null)
       assert.deepStrictEqual(log.values[0].identity, testIdentity.toJSON())
     })
 
-    it('doesn\'t sign entries when identity is not defined', async () => {
+    it.skip('doesn\'t sign entries when identity is not defined', async () => {
       let err
       try {
         const log = new Log(ipfs) // eslint-disable-line no-unused-vars
@@ -91,7 +91,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
       assert.strictEqual(err.message, 'Identity is required')
     })
 
-    it('doesn\'t join logs with different IDs ', async () => {
+    it.skip('doesn\'t join logs with different IDs ', async () => {
       const log1 = new Log(ipfs, testIdentity, { logId: 'A' })
       const log2 = new Log(ipfs, testIdentity2, { logId: 'B' })
 
@@ -112,7 +112,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
       assert.strictEqual(log1.values[0].payload, 'one')
     })
 
-    it('throws an error if log is signed but trying to merge with an entry that doesn\'t have public signing key', async () => {
+    it.skip('throws an error if log is signed but trying to merge with an entry that doesn\'t have public signing key', async () => {
       const log1 = new Log(ipfs, testIdentity, { logId: 'A' })
       const log2 = new Log(ipfs, testIdentity2, { logId: 'A' })
 
@@ -128,7 +128,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
       assert.strictEqual(err, 'Error: Entry doesn\'t have a key')
     })
 
-    it('throws an error if log is signed but trying to merge an entry that doesn\'t have a signature', async () => {
+    it.skip('throws an error if log is signed but trying to merge an entry that doesn\'t have a signature', async () => {
       const log1 = new Log(ipfs, testIdentity, { logId: 'A' })
       const log2 = new Log(ipfs, testIdentity2, { logId: 'A' })
 
@@ -144,7 +144,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
       assert.strictEqual(err, 'Error: Entry doesn\'t have a signature')
     })
 
-    it('throws an error if log is signed but the signature doesn\'t verify', async () => {
+    it.skip('throws an error if log is signed but the signature doesn\'t verify', async () => {
       const log1 = new Log(ipfs, testIdentity, { logId: 'A' })
       const log2 = new Log(ipfs, testIdentity2, { logId: 'A' })
       let err
@@ -164,7 +164,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
       assert.strictEqual(log1.values[0].payload, 'one')
     })
 
-    it('throws an error if entry doesn\'t have append access', async () => {
+    it.skip('throws an error if entry doesn\'t have append access', async () => {
       const denyAccess = { canAppend: () => false }
       const log1 = new Log(ipfs, testIdentity, { logId: 'A' })
       const log2 = new Log(ipfs, testIdentity2, { logId: 'A', access: denyAccess })
@@ -181,7 +181,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
       assert.strictEqual(err, `Error: Could not append entry, key "${testIdentity2.id}" is not allowed to write to the log`)
     })
 
-    it('throws an error upon join if entry doesn\'t have append access', async () => {
+    it.skip('throws an error upon join if entry doesn\'t have append access', async () => {
       let testACL = {
         canAppend: (entry) => entry.identity.id !== testIdentity2.id
       }


### PR DESCRIPTION
> ⚠️  NOTE: Please don't use the PR description for communication, use comments instead.

## Description (Required)

This PR is meant to land in OrbitDB 0.19 to disable the `ipfs-log` append function and throw an error instructing users to upgrade.

## Other changes (e.g. bug fixes, UI tweaks, refactors)

Lots of disabled tests

## TODO

- [ ] Update to/from Multihash
- [ ] Apply to/fromMultihash commit to ipfs-log 4.3.0