### PR TITLE
Add setIdentity method

### DIFF
--- a/src/log.js
+++ b/src/log.js
@@ -165,6 +165,17 @@ class Log extends GSet {
   }
 
   /**
+   * Set the identity for the log
+   * @param {Identity} [identity] The identity to be set
+   */
+  setIdentity (identity) {
+    this._identity = identity
+    // Find the latest clock from the heads
+    const time = Math.max(this.clock.time, this.heads.reduce(maxClockTimeReducer, 0))
+    this._clock = new Clock(this._identity.publicKey, time)
+  }
+
+  /**
    * Find an entry.
    * @param {string} [hash] The hashes of the entry
    * @returns {Entry|undefined}

--- a/test/log.spec.js
+++ b/test/log.spec.js
@@ -203,6 +203,28 @@ Object.keys(testAPIs).forEach((IPFS) => {
       })
     })
 
+    describe('setIdentity', () => {
+      let log
+
+      beforeEach(async () => {
+        log = new Log(ipfs, testIdentity, { logId: 'AAA' })
+        await log.append('one')
+      })
+
+      it('changes identity', async () => {
+        assert.strictEqual(log.values[0].clock.id, testIdentity.publicKey)
+        assert.strictEqual(log.values[0].clock.time, 1)
+        log.setIdentity(testIdentity2)
+        await log.append('two')
+        assert.strictEqual(log.values[1].clock.id, testIdentity2.publicKey)
+        assert.strictEqual(log.values[1].clock.time, 2)
+        log.setIdentity(testIdentity3)
+        await log.append('three')
+        assert.strictEqual(log.values[2].clock.id, testIdentity3.publicKey)
+        assert.strictEqual(log.values[2].clock.time, 3)
+      })
+    })
+
     describe('has', async () => {
       let log, expectedData
 


### PR DESCRIPTION
## Description
This PR adds a `setIdentity` method so that identities can be changed when the log is already initialized. The reason for adding this is that we might want to start syncing a database before the user has been authenticated.

I wasn't sure if I should make it into a method like this or a javascript setter. Let me know if I should change it.