### PR TITLE
add options arg to Entry.toMultihash

### DIFF
--- a/src/entry.js
+++ b/src/entry.js
@@ -49,7 +49,7 @@ class Entry {
     entry.key = identity.publicKey
     entry.identity = identity.toJSON()
     entry.sig = signature
-    entry.hash = await Entry.toMultihash(ipfs, entry, pin)
+    entry.hash = await Entry.toMultihash(ipfs, entry, { pin })
 
     return entry
   }
@@ -93,13 +93,13 @@ class Entry {
    * // "Qm...Foo"
    * @deprecated
    */
-  static async toMultihash (ipfs, entry, pin = false) {
+  static async toMultihash (ipfs, entry, { pin = false, onlyHash = false } = {}) {
     if (!ipfs) throw IpfsNotDefinedError()
     if (!Entry.isEntry(entry)) throw new Error('Invalid object format, cannot generate entry hash')
 
     // // Ensure `entry` follows the correct format
     const e = Entry.toEntry(entry)
-    return io.write(ipfs, getWriteFormat(e.v), e, { links: IPLD_LINKS, pin })
+    return io.write(ipfs, getWriteFormat(e.v), e, { links: IPLD_LINKS, pin, onlyHash })
   }
 
   static toEntry (entry, { presigned = false, includeHash = false } = {}) {

--- a/test/entry.spec.js
+++ b/test/entry.spec.js
@@ -4,9 +4,7 @@ const assert = require('assert')
 const rmrf = require('rimraf')
 const fs = require('fs-extra')
 const Entry = require('../src/entry')
-const Log = require('../src/log')
 const { io } = require('../src/utils')
-const AccessController = Log.AccessController
 const IdentityProvider = require('orbit-db-identity-provider')
 const v0Entries = require('./fixtures/v0-entries.fixture')
 const v1Entries = require('./fixtures/v1-entries.fixture')
@@ -26,7 +24,6 @@ Object.keys(testAPIs).forEach((IPFS) => {
   describe('Entry (' + IPFS + ')', function () {
     this.timeout(config.timeout)
 
-    const testACL = new AccessController()
     const { identityKeyFixtures, signingKeyFixtures, identityKeysPath, signingKeysPath } = config
     const ipfsConfig = Object.assign({}, config.defaultIpfsConfig, {
       repo: config.defaultIpfsConfig.repo + '-entry' + new Date().getTime()
@@ -205,7 +202,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
       it('throws an error if the object being passed is invalid', async () => {
         let err1, err2
         try {
-          await Entry.toMultihash(ipfs, testACL, testIdentity, { hash: 'deadbeef' })
+          await Entry.toMultihash(ipfs, { hash: 'deadbeef' })
         } catch (e) {
           err1 = e
         }


### PR DESCRIPTION
Changes last argument of `Entry.toMultihash` to options object, adds `onlyHash` option