### PR TITLE
fix: io v1 entries with no refs

### DIFF
--- a/src/entry-io.js
+++ b/src/entry-io.js
@@ -114,11 +114,12 @@ class EntryIO {
                 onProgressCallback(hash, entry, result.length, result.length)
               }
             }
+            if (!entry.refs) entry.refs = []
 
             if (length < 0) {
               // If we're fetching all entries (length === -1), adds nexts and refs to the queue
               entry.next.forEach(addToLoadingQueue)
-              if (entry.refs) entry.refs.forEach(addToLoadingQueue)
+              entry.refs.forEach(addToLoadingQueue)
             } else {
               // If we're fetching entries up to certain length,
               // fetch the next if result is filled up, to make sure we "check"


### PR DESCRIPTION
## Description 
 
fix for loading v1 entries with no refs

Seen while upgrading orbitdb from 0.22 -> 0.23 in 3Box. 

Have not read through the rest of the code here to be able to tell if it is expected that entries with not refs would not use that code path (lines 130 - 132), but this fix seems to have resolved the issue for 3box. We are also fetching all entries, so not sure also what changed so that here this would not resolve as length  -1. 

## TODO
- [ ] Update snapshots if this is the fix 


