### PR TITLE
Fix example and change randomId function

### DIFF
--- a/examples/log.js
+++ b/examples/log.js
@@ -27,9 +27,9 @@ ipfs.on('ready', async () => {
     console.error(e)
   }
 
-  let log1 = new Log(ipfs, identityA, { lodId: 'A' })
-  let log2 = new Log(ipfs, identityB, { lodId: 'A' })
-  let log3 = new Log(ipfs, identityC, { lodId: 'A' })
+  let log1 = new Log(ipfs, identityA, { logId: 'A' })
+  let log2 = new Log(ipfs, identityB, { logId: 'A' })
+  let log3 = new Log(ipfs, identityC, { logId: 'A' })
 
   try {
     await log1.append('one')

--- a/src/log.js
+++ b/src/log.js
@@ -9,9 +9,8 @@ const Clock = require('./lamport-clock')
 const Sorting = require('./log-sorting')
 const { LastWriteWins, NoZeroes } = Sorting
 const AccessController = require('./default-access-controller')
-const { isDefined, findUniques } = require('./utils')
+const { isDefined, findUniques, randomId } = require('./utils')
 const EntryIndex = require('./entry-index')
-const randomId = () => new Date().getTime().toString()
 const getHash = e => e.hash
 const flatMap = (res, acc) => res.concat(acc)
 const getNextPointers = entry => entry.next
@@ -75,7 +74,7 @@ class Log extends GSet {
     this._sortFn = NoZeroes(sortFn)
 
     this._storage = ipfs
-    this._id = logId || randomId()
+    this._id = logId || randomId(42)
 
     // Access Controller
     this._access = access

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -4,10 +4,12 @@ const difference = require('./difference')
 const findUniques = require('./find-uniques')
 const isDefined = require('./is-defined')
 const io = require('orbit-db-io')
+const randomId = require('./random-id')
 
 module.exports = {
   difference,
   findUniques,
   isDefined,
-  io
+  io,
+  randomId
 }

--- a/src/utils/random-id.js
+++ b/src/utils/random-id.js
@@ -1,0 +1,14 @@
+'use strict'
+
+function randomId (length) {
+  // Credit: https://stackoverflow.com/a/1349426
+  let result = ''
+  const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+  const charactersLength = characters.length
+  for (let i = 0; i < length; i++) {
+    result += characters.charAt(Math.floor(Math.random() * charactersLength))
+  }
+  return result
+}
+
+module.exports = randomId


### PR DESCRIPTION
> ⚠️  NOTE: Please don't use the PR description for communication, use comments instead.

## Description (Required)

- Fixes the example (`lodId` -> `logId` typo)

- Changes the `randomId` function in `src/log.js` to prevent confusion: without this the "random" log id could be the same. The example would seem to work but other times it could print
```text
four
└─three
```
This might cause confusion when missusing the library like the example did.
In you run the broken example with the new `randomId` function it would reliably output:
```
four
```
