### PR TITLE
fix: dont pass fetchParallel log concurrency value to fetchAll entry concurrency

### DIFF
--- a/src/entry-io.js
+++ b/src/entry-io.js
@@ -8,12 +8,12 @@ const hasItems = arr => arr && arr.length > 0
 
 class EntryIO {
   // Fetch log graphs in parallel
-  static async fetchParallel (ipfs, hashes, { length, exclude = [], timeout, concurrency, onProgressCallback }) {
-    concurrency = Math.max(concurrency || hashes.length, 1)
+  static async fetchParallel (ipfs, hashes, { length, exclude = [], timeout, concurrency, logConcurrency, onProgressCallback }) {
     const fetchOne = async (hash) => EntryIO.fetchAll(ipfs, hash, { length, exclude, timeout, onProgressCallback, concurrency })
+    logConcurrency = Math.max(logConcurrency || hashes.length, 1)
     const concatArrays = (arr1, arr2) => arr1.concat(arr2)
     const flatten = (arr) => arr.reduce(concatArrays, [])
-    const res = await pMap(hashes, fetchOne, { concurrency })
+    const res = await pMap(hashes, fetchOne, { concurrency: logConcurrency })
     return flatten(res)
   }
 


### PR DESCRIPTION
Was still linearly fetching entries. Concurrency values passed to fetchParallel was undefined, then set to 1 or hash.length. It looks like this value was intended to be the fetchParrallel (log) concurrency. But is was also being passed to fetchAll in the fetchOne function. Often this value was 1 or much less than 32 so often fetched linearly or not much faster. 

Otherwise the entry refs are awesome! saw huge speed up when syncing from remote ipfs node once parallelized, compared to before.

Let me know if this was not what was intended or if there is any code changes needed elsewhere with this. 