### PR TITLE
update orbit-db-test-utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "nyc": "^15.0.1",
     "orbit-db-benchmark-runner": "^1.0.3",
     "orbit-db-storage-adapter": "^0.5.3",
-    "orbit-db-test-utils": "~0.12.1",
+    "orbit-db-test-utils": "github:tabcat/orbit-db-test-utils#support-latest",
     "rimraf": "~3.0.2",
     "standard": "~16.0.3",
     "webpack": "~4.44.2",


### PR DESCRIPTION
This pr updates orbit-db-test-utils if https://github.com/orbitdb/orbit-db-test-utils/pull/30 is merged.

The update will use newer versions of ipfs, js-ipfs 0.52.0 and go-ipfs v0.7.0, and potentially reduces frequency of test timeouts.

clone or pull https://github.com/tabcat/ipfs-log/tree/update-test-util to install and run tests