### PR TITLE
tests use tmp ipfs repo

### DIFF
--- a/test/entry-io.spec.js
+++ b/test/entry-io.spec.js
@@ -25,14 +25,10 @@ Object.keys(testAPIs).forEach((IPFS) => {
     this.timeout(config.timeout)
 
     const { identityKeyFixtures, signingKeyFixtures, identityKeysPath, signingKeysPath } = config
-    const ipfsConfig = Object.assign({}, config.defaultIpfsConfig, {
-      repo: config.defaultIpfsConfig.repo + '-entry-io' + new Date().getTime()
-    })
 
     let options, keystore, signingKeystore
 
     before(async () => {
-      rmrf.sync(ipfsConfig.repo)
       rmrf.sync(identityKeysPath)
       rmrf.sync(signingKeysPath)
       await fs.copy(identityKeyFixtures, identityKeysPath)
@@ -51,13 +47,12 @@ Object.keys(testAPIs).forEach((IPFS) => {
       testIdentity2 = await IdentityProvider.createIdentity(options[1])
       testIdentity3 = await IdentityProvider.createIdentity(options[2])
       testIdentity4 = await IdentityProvider.createIdentity(options[3])
-      ipfsd = await startIpfs(IPFS, ipfsConfig)
+      ipfsd = await startIpfs(IPFS, config.defaultIpfsConfig)
       ipfs = ipfsd.api
     })
 
     after(async () => {
       await stopIpfs(ipfsd)
-      rmrf.sync(ipfsConfig.repo)
       rmrf.sync(identityKeysPath)
       rmrf.sync(signingKeysPath)
 

--- a/test/entry.spec.js
+++ b/test/entry.spec.js
@@ -28,14 +28,10 @@ Object.keys(testAPIs).forEach((IPFS) => {
 
     const testACL = new AccessController()
     const { identityKeyFixtures, signingKeyFixtures, identityKeysPath, signingKeysPath } = config
-    const ipfsConfig = Object.assign({}, config.defaultIpfsConfig, {
-      repo: config.defaultIpfsConfig.repo + '-entry' + new Date().getTime()
-    })
 
     let keystore, signingKeystore
 
     before(async () => {
-      rmrf.sync(ipfsConfig.repo)
       await fs.copy(identityKeyFixtures, identityKeysPath)
       await fs.copy(signingKeyFixtures, signingKeysPath)
 
@@ -43,7 +39,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
       signingKeystore = new Keystore(signingKeysPath)
 
       testIdentity = await IdentityProvider.createIdentity({ id: 'userA', keystore, signingKeystore })
-      ipfsd = await startIpfs(IPFS, ipfsConfig)
+      ipfsd = await startIpfs(IPFS, config.defaultIpfsConfig)
       ipfs = ipfsd.api
     })
 
@@ -53,7 +49,6 @@ Object.keys(testAPIs).forEach((IPFS) => {
       await fs.copy(signingKeyFixtures, signingKeysPath)
       rmrf.sync(identityKeysPath)
       rmrf.sync(signingKeysPath)
-      rmrf.sync(ipfsConfig.repo)
       await keystore.close()
       await signingKeystore.close()
     })

--- a/test/log-append.spec.js
+++ b/test/log-append.spec.js
@@ -22,14 +22,10 @@ Object.keys(testAPIs).forEach((IPFS) => {
     this.timeout(config.timeout)
 
     const { identityKeyFixtures, signingKeyFixtures, identityKeysPath, signingKeysPath } = config
-    const ipfsConfig = Object.assign({}, config.defaultIpfsConfig, {
-      repo: config.defaultIpfsConfig.repo + '-log-append' + new Date().getTime()
-    })
 
     let keystore, signingKeystore
 
     before(async () => {
-      rmrf.sync(ipfsConfig.repo)
       rmrf.sync(identityKeysPath)
       rmrf.sync(signingKeysPath)
       await fs.copy(identityKeyFixtures, identityKeysPath)
@@ -39,13 +35,12 @@ Object.keys(testAPIs).forEach((IPFS) => {
       signingKeystore = new Keystore(signingKeysPath)
 
       testIdentity = await IdentityProvider.createIdentity({ id: 'userA', keystore, signingKeystore })
-      ipfsd = await startIpfs(IPFS, ipfsConfig)
+      ipfsd = await startIpfs(IPFS, config.defaultIpfsConfig)
       ipfs = ipfsd.api
     })
 
     after(async () => {
       await stopIpfs(ipfsd)
-      rmrf.sync(ipfsConfig.repo)
       rmrf.sync(identityKeysPath)
       rmrf.sync(signingKeysPath)
 

--- a/test/log-crdt.spec.js
+++ b/test/log-crdt.spec.js
@@ -22,14 +22,10 @@ Object.keys(testAPIs).forEach((IPFS) => {
     this.timeout(config.timeout)
 
     const { identityKeyFixtures, signingKeyFixtures, identityKeysPath, signingKeysPath } = config
-    const ipfsConfig = Object.assign({}, config.defaultIpfsConfig, {
-      repo: config.defaultIpfsConfig.repo + '-log-crdt' + new Date().getTime()
-    })
 
     let keystore, signingKeystore
 
     before(async () => {
-      rmrf.sync(ipfsConfig.repo)
       rmrf.sync(identityKeysPath)
       rmrf.sync(signingKeysPath)
       await fs.copy(identityKeyFixtures, identityKeysPath)
@@ -41,13 +37,12 @@ Object.keys(testAPIs).forEach((IPFS) => {
       testIdentity = await IdentityProvider.createIdentity({ id: 'userA', keystore, signingKeystore })
       testIdentity2 = await IdentityProvider.createIdentity({ id: 'userB', keystore, signingKeystore })
       testIdentity3 = await IdentityProvider.createIdentity({ id: 'userC', keystore, signingKeystore })
-      ipfsd = await startIpfs(IPFS, ipfsConfig)
+      ipfsd = await startIpfs(IPFS, config.defaultIpfsConfig)
       ipfs = ipfsd.api
     })
 
     after(async () => {
       await stopIpfs(ipfsd)
-      rmrf.sync(ipfsConfig.repo)
       rmrf.sync(identityKeysPath)
       rmrf.sync(signingKeysPath)
 

--- a/test/log-heads-tails.spec.js
+++ b/test/log-heads-tails.spec.js
@@ -27,14 +27,10 @@ Object.keys(testAPIs).forEach((IPFS) => {
     this.timeout(config.timeout)
 
     const { identityKeyFixtures, signingKeyFixtures, identityKeysPath, signingKeysPath } = config
-    const ipfsConfig = Object.assign({}, config.defaultIpfsConfig, {
-      repo: config.defaultIpfsConfig.repo + '-log-head-and-tails' + new Date().getTime()
-    })
 
     let keystore, signingKeystore
 
     before(async () => {
-      rmrf.sync(ipfsConfig.repo)
       rmrf.sync(identityKeysPath)
       rmrf.sync(signingKeysPath)
       await fs.copy(identityKeyFixtures, identityKeysPath)
@@ -47,13 +43,12 @@ Object.keys(testAPIs).forEach((IPFS) => {
       testIdentity2 = await IdentityProvider.createIdentity({ id: 'userB', keystore, signingKeystore })
       testIdentity3 = await IdentityProvider.createIdentity({ id: 'userC', keystore, signingKeystore })
       testIdentity4 = await IdentityProvider.createIdentity({ id: 'userD', keystore, signingKeystore })
-      ipfsd = await startIpfs(IPFS, ipfsConfig)
+      ipfsd = await startIpfs(IPFS, config.defaultIpfsConfig)
       ipfs = ipfsd.api
     })
 
     after(async () => {
       await stopIpfs(ipfsd)
-      rmrf.sync(ipfsConfig.repo)
       rmrf.sync(identityKeysPath)
       rmrf.sync(signingKeysPath)
 

--- a/test/log-iterator.spec.js
+++ b/test/log-iterator.spec.js
@@ -23,14 +23,10 @@ Object.keys(testAPIs).forEach((IPFS) => {
     this.timeout(config.timeout)
 
     const { identityKeyFixtures, signingKeyFixtures, identityKeysPath, signingKeysPath } = config
-    const ipfsConfig = Object.assign({}, config.defaultIpfsConfig, {
-      repo: config.defaultIpfsConfig.repo + '-log-join' + new Date().getTime()
-    })
 
     let keystore, signingKeystore
 
     before(async () => {
-      rmrf.sync(ipfsConfig.repo)
       rmrf.sync(identityKeysPath)
       rmrf.sync(signingKeysPath)
       await fs.copy(identityKeyFixtures, identityKeysPath)
@@ -42,13 +38,12 @@ Object.keys(testAPIs).forEach((IPFS) => {
       testIdentity = await IdentityProvider.createIdentity({ id: 'userA', keystore, signingKeystore })
       testIdentity2 = await IdentityProvider.createIdentity({ id: 'userB', keystore, signingKeystore })
       testIdentity3 = await IdentityProvider.createIdentity({ id: 'userC', keystore, signingKeystore })
-      ipfsd = await startIpfs(IPFS, ipfsConfig)
+      ipfsd = await startIpfs(IPFS, config.defaultIpfsConfig)
       ipfs = ipfsd.api
     })
 
     after(async () => {
       await stopIpfs(ipfsd)
-      rmrf.sync(ipfsConfig.repo)
       rmrf.sync(identityKeysPath)
       rmrf.sync(signingKeysPath)
 

--- a/test/log-join-concurrent.spec.js
+++ b/test/log-join-concurrent.spec.js
@@ -21,18 +21,14 @@ Object.keys(testAPIs).forEach(IPFS => {
     this.timeout(config.timeout)
 
     const { identityKeyFixtures, signingKeyFixtures, identityKeysPath, signingKeysPath } = config
-    const ipfsConfig = Object.assign({}, config.defaultIpfsConfig, {
-      repo: config.defaultIpfsConfig.repo + '-log-join-concurrent' + new Date().getTime()
-    })
 
     before(async () => {
-      rmrf.sync(ipfsConfig.repo)
       rmrf.sync(identityKeysPath)
       rmrf.sync(signingKeysPath)
       await fs.copy(identityKeyFixtures, identityKeysPath)
       await fs.copy(signingKeyFixtures, signingKeysPath)
       testIdentity = await IdentityProvider.createIdentity({ id: 'userA', identityKeysPath, signingKeysPath })
-      ipfsd = await startIpfs(IPFS, ipfsConfig)
+      ipfsd = await startIpfs(IPFS, config.defaultIpfsConfig)
       ipfs = ipfsd.api
     })
 
@@ -40,7 +36,6 @@ Object.keys(testAPIs).forEach(IPFS => {
       await stopIpfs(ipfsd)
       await testIdentity.provider.keystore.close()
       await testIdentity.provider.signingKeystore.close()
-      rmrf.sync(ipfsConfig.repo)
       rmrf.sync(identityKeysPath)
       rmrf.sync(signingKeysPath)
     })

--- a/test/log-join.spec.js
+++ b/test/log-join.spec.js
@@ -28,14 +28,10 @@ Object.keys(testAPIs).forEach((IPFS) => {
     this.timeout(config.timeout)
 
     const { identityKeyFixtures, signingKeyFixtures, identityKeysPath, signingKeysPath } = config
-    const ipfsConfig = Object.assign({}, config.defaultIpfsConfig, {
-      repo: config.defaultIpfsConfig.repo + '-log-join' + new Date().getTime()
-    })
 
     let keystore, signingKeystore
 
     before(async () => {
-      rmrf.sync(ipfsConfig.repo)
       rmrf.sync(identityKeysPath)
       rmrf.sync(signingKeysPath)
       await fs.copy(identityKeyFixtures, identityKeysPath)
@@ -49,13 +45,12 @@ Object.keys(testAPIs).forEach((IPFS) => {
       testIdentity3 = await IdentityProvider.createIdentity({ id: 'userD', keystore, signingKeystore })
       testIdentity4 = await IdentityProvider.createIdentity({ id: 'userA', keystore, signingKeystore })
 
-      ipfsd = await startIpfs(IPFS, ipfsConfig)
+      ipfsd = await startIpfs(IPFS, config.defaultIpfsConfig)
       ipfs = ipfsd.api
     })
 
     after(async () => {
       await stopIpfs(ipfsd)
-      rmrf.sync(ipfsConfig.repo)
       rmrf.sync(identityKeysPath)
       rmrf.sync(signingKeysPath)
 

--- a/test/log-load.spec.js
+++ b/test/log-load.spec.js
@@ -38,9 +38,6 @@ Object.keys(testAPIs).forEach((IPFS) => {
     this.timeout(config.timeout)
 
     const { identityKeyFixtures, signingKeyFixtures, identityKeysPath, signingKeysPath } = config
-    const ipfsConfig = Object.assign({}, config.defaultIpfsConfig, {
-      repo: config.defaultIpfsConfig.repo + '-log-load' + new Date().getTime()
-    })
 
     const firstWriteExpectedData = [
       'entryA6', 'entryA7', 'entryA8', 'entryA9',
@@ -52,7 +49,6 @@ Object.keys(testAPIs).forEach((IPFS) => {
     let keystore, signingKeystore
 
     before(async () => {
-      rmrf.sync(ipfsConfig.repo)
       rmrf.sync(identityKeysPath)
       rmrf.sync(signingKeysPath)
       await fs.copy(identityKeyFixtures, identityKeysPath)
@@ -65,7 +61,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
       testIdentity2 = await IdentityProvider.createIdentity({ id: 'userB', keystore, signingKeystore })
       testIdentity3 = await IdentityProvider.createIdentity({ id: 'userD', keystore, signingKeystore })
       testIdentity4 = await IdentityProvider.createIdentity({ id: 'userA', keystore, signingKeystore })
-      ipfsd = await startIpfs(IPFS, ipfsConfig)
+      ipfsd = await startIpfs(IPFS, config.defaultIpfsConfig)
       ipfs = ipfsd.api
 
       const memstore = new MemStore()
@@ -75,7 +71,6 @@ Object.keys(testAPIs).forEach((IPFS) => {
 
     after(async () => {
       await stopIpfs(ipfsd)
-      rmrf.sync(ipfsConfig.repo)
       rmrf.sync(identityKeysPath)
       rmrf.sync(signingKeysPath)
 

--- a/test/log-references.spec.js
+++ b/test/log-references.spec.js
@@ -22,14 +22,10 @@ Object.keys(testAPIs).forEach((IPFS) => {
     this.timeout(config.timeout)
 
     const { identityKeyFixtures, signingKeyFixtures, identityKeysPath, signingKeysPath } = config
-    const ipfsConfig = Object.assign({}, config.defaultIpfsConfig, {
-      repo: config.defaultIpfsConfig.repo + '-log-refs' + new Date().getTime()
-    })
 
     let keystore, signingKeystore
 
     before(async () => {
-      rmrf.sync(ipfsConfig.repo)
       rmrf.sync(identityKeysPath)
       rmrf.sync(signingKeysPath)
       await fs.copy(identityKeyFixtures, identityKeysPath)
@@ -39,13 +35,12 @@ Object.keys(testAPIs).forEach((IPFS) => {
       signingKeystore = new Keystore(signingKeysPath)
 
       testIdentity = await IdentityProvider.createIdentity({ id: 'userA', keystore, signingKeystore })
-      ipfsd = await startIpfs(IPFS, ipfsConfig)
+      ipfsd = await startIpfs(IPFS, config.defaultIpfsConfig)
       ipfs = ipfsd.api
     })
 
     after(async () => {
       await stopIpfs(ipfsd)
-      rmrf.sync(ipfsConfig.repo)
       rmrf.sync(identityKeysPath)
       rmrf.sync(signingKeysPath)
 

--- a/test/log.spec.js
+++ b/test/log.spec.js
@@ -29,16 +29,12 @@ Object.keys(testAPIs).forEach((IPFS) => {
     this.timeout(config.timeout)
 
     const { identityKeyFixtures, signingKeyFixtures, identityKeysPath, signingKeysPath } = config
-    const ipfsConfig = Object.assign({}, config.defaultIpfsConfig, {
-      repo: config.defaultIpfsConfig.repo + '-log' + new Date().getTime()
-    })
 
     let keystore, signingKeystore
 
     before(async () => {
       await fs.copy(identityKeyFixtures, identityKeysPath)
       await fs.copy(signingKeyFixtures, signingKeysPath)
-      rmrf.sync(ipfsConfig.repo)
 
       keystore = new Keystore(identityKeysPath)
       signingKeystore = new Keystore(signingKeysPath)
@@ -46,7 +42,7 @@ Object.keys(testAPIs).forEach((IPFS) => {
       testIdentity = await IdentityProvider.createIdentity({ id: 'userA', keystore, signingKeystore })
       testIdentity2 = await IdentityProvider.createIdentity({ id: 'userB', keystore, signingKeystore })
       testIdentity3 = await IdentityProvider.createIdentity({ id: 'userC', keystore, signingKeystore })
-      ipfsd = await startIpfs(IPFS, ipfsConfig)
+      ipfsd = await startIpfs(IPFS, config.defaultIpfsConfig)
       ipfs = ipfsd.api
     })
 
@@ -54,7 +50,6 @@ Object.keys(testAPIs).forEach((IPFS) => {
       await stopIpfs(ipfsd)
       rmrf.sync(signingKeysPath)
       rmrf.sync(identityKeysPath)
-      rmrf.sync(ipfsConfig.repo)
 
       await keystore.close()
       await signingKeystore.close()

--- a/test/signed-log.spec.js
+++ b/test/signed-log.spec.js
@@ -22,14 +22,10 @@ Object.keys(testAPIs).forEach((IPFS) => {
     this.timeout(config.timeout)
 
     const { identityKeyFixtures, signingKeyFixtures, identityKeysPath, signingKeysPath } = config
-    const ipfsConfig = Object.assign({}, config.defaultIpfsConfig, {
-      repo: config.defaultIpfsConfig.repo + '-log-signed' + new Date().getTime()
-    })
 
     let keystore, signingKeystore
 
     before(async () => {
-      rmrf.sync(ipfsConfig.repo)
       rmrf.sync(identityKeysPath)
       rmrf.sync(signingKeysPath)
       await fs.copy(identityKeyFixtures, identityKeysPath)
@@ -40,13 +36,12 @@ Object.keys(testAPIs).forEach((IPFS) => {
 
       testIdentity = await IdentityProvider.createIdentity({ id: 'userA', keystore, signingKeystore })
       testIdentity2 = await IdentityProvider.createIdentity({ id: 'userB', keystore, signingKeystore })
-      ipfsd = await startIpfs(IPFS, ipfsConfig)
+      ipfsd = await startIpfs(IPFS, config.defaultIpfsConfig)
       ipfs = ipfsd.api
     })
 
     after(async () => {
       await stopIpfs(ipfsd)
-      rmrf.sync(ipfsConfig.repo)
       rmrf.sync(identityKeysPath)
       rmrf.sync(signingKeysPath)
       await keystore.close()


### PR DESCRIPTION
Ipfs-log tests now use tmp ipfs repo just like OrbitDB tests.

changes to affected test files:
 - removed edited orbit-db-test-utils ipfs config that added repo option
 - removed rmrf calls to delete ipfs repo
 - startIpfs now uses config.defaultIpfsConfig instead of version with repo option added

Closes https://github.com/orbitdb/ipfs-log/issues/321
