### PR TITLE
toBaseEncodedString -> toString

### DIFF
--- a/lib/es5/utils/dag-node.js
+++ b/lib/es5/utils/dag-node.js
@@ -6,7 +6,9 @@ var _regenerator = _interopRequireDefault(require("@babel/runtime/regenerator"))
 
 var _asyncToGenerator2 = _interopRequireDefault(require("@babel/runtime/helpers/asyncToGenerator"));
 
-var CID = require('cids');
+const CID = require('multiformats/cid');
+
+const { base58btc } = require('multiformats/bases/base58')
 
 var dagPB = require('ipld-dag-pb');
 
@@ -37,7 +39,7 @@ var stringifyCid = function stringifyCid(cid) {
     return cid.map(stringifyCid);
   }
 
-  return cid.toString();
+  return cid.toString(base58btc);
 };
 
 var writePb =
@@ -65,7 +67,7 @@ function () {
 
           case 6:
             cid = _context.sent;
-            return _context.abrupt("return", cid.toV0().toString());
+            return _context.abrupt("return", cid.toV0().toString(base58btc));
 
           case 8:
           case "end":
@@ -132,7 +134,7 @@ function () {
 
           case 4:
             cid = _context3.sent;
-            return _context3.abrupt("return", cid.toString());
+            return _context3.abrupt("return", cid.toString(base58btc));
 
           case 6:
           case "end":

--- a/lib/es5/utils/dag-node.js
+++ b/lib/es5/utils/dag-node.js
@@ -37,7 +37,7 @@ var stringifyCid = function stringifyCid(cid) {
     return cid.map(stringifyCid);
   }
 
-  return cid.toBaseEncodedString();
+  return cid.toString();
 };
 
 var writePb =
@@ -65,7 +65,7 @@ function () {
 
           case 6:
             cid = _context.sent;
-            return _context.abrupt("return", cid.toV0().toBaseEncodedString());
+            return _context.abrupt("return", cid.toV0().toString());
 
           case 8:
           case "end":
@@ -132,7 +132,7 @@ function () {
 
           case 4:
             cid = _context3.sent;
-            return _context3.abrupt("return", cid.toBaseEncodedString());
+            return _context3.abrupt("return", cid.toString());
 
           case 6:
           case "end":


### PR DESCRIPTION

> ⚠️  NOTE: Please don't use the PR description for communication, use comments instead.

## Description (Required)
toBaseEncodedString is deprecated and throws an error in the current IPFS version

