### PR TITLE
Don't run benchmarks on regular test run in CI

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,8 +18,6 @@ jobs:
         run: npm run lint
       - name: Run tests
         run: npm run test
-      - name: Run benchmarks
-        run: npm run benchmark
   test-browser:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This PR removes the benchmarks from the regular test run on CI.